### PR TITLE
Add kanban tracker board

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
+import "./tracker/tracker.css";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",

--- a/src/app/tracker/TrackerPage.tsx
+++ b/src/app/tracker/TrackerPage.tsx
@@ -1,0 +1,165 @@
+"use client";
+
+import { useMemo, useState, type DragEvent } from "react";
+import { ListFilter, Search, Sparkles } from "lucide-react";
+import StageColumn from "./components/StageColumn";
+import VoiceControl from "./components/VoiceControl";
+import { INITIAL_JOBS, STAGES, type JobItem, type JobStage } from "./data";
+import { filterJobs, groupJobsByStage } from "./utils";
+
+const TrackerPage = () => {
+    const [jobs, setJobs] = useState<JobItem[]>(INITIAL_JOBS);
+    const [searchQuery, setSearchQuery] = useState("");
+    const [selectedStage, setSelectedStage] = useState<JobStage | null>(null);
+    const [activeId, setActiveId] = useState<string | null>(null);
+
+    const filteredJobs = useMemo(
+        () => filterJobs(jobs, searchQuery, selectedStage),
+        [jobs, searchQuery, selectedStage]
+    );
+    const groupedJobs = useMemo(() => groupJobsByStage(filteredJobs), [filteredJobs]);
+
+    const stageCounts = useMemo(() => {
+        return jobs.reduce<Record<JobStage, number>>(
+            (acc, job) => {
+                acc[job.stage] += 1;
+                return acc;
+            },
+            {
+                WISHLIST: 0,
+                APPLIED: 0,
+                INTERVIEW: 0,
+                OFFER: 0,
+                REJECTED: 0,
+            }
+        );
+    }, [jobs]);
+
+    const moveJob = (jobId: string, stage: JobStage) => {
+        setJobs((prev) =>
+            prev.map((job) =>
+                job.id === jobId
+                    ? { ...job, stage, appliedDate: new Date().toISOString().split("T")[0] }
+                    : job
+            )
+        );
+    };
+
+    const handleDragStart = (id: string, event: DragEvent<HTMLDivElement>) => {
+        event.dataTransfer?.setData("text/plain", id);
+        setActiveId(id);
+    };
+
+    const handleDragEnd = () => {
+        setActiveId(null);
+    };
+
+    const handleDrop = (stage: JobStage, event: DragEvent<HTMLDivElement>) => {
+        const droppedId = event.dataTransfer?.getData("text/plain") || activeId;
+        if (droppedId) {
+            moveJob(droppedId, stage);
+        }
+        setActiveId(null);
+    };
+
+    const handleAddJob = () => {
+        if (typeof window === "undefined") return;
+        const role = window.prompt("What role are you tracking?");
+        if (!role) return;
+        const company = window.prompt("Which company is it for?") || "Unknown company";
+        const location = window.prompt("Where is the role located?") || "Remote";
+
+        const newJob: JobItem = {
+            id: `${Date.now()}`,
+            role,
+            company,
+            location,
+            stage: "WISHLIST",
+            appliedDate: new Date().toISOString().split("T")[0],
+            notes: 0,
+            isSaved: false,
+        };
+
+        setJobs((prev) => [newJob, ...prev]);
+    };
+
+    return (
+        <div className="tracker-page">
+            <div className="tracker-backdrop" aria-hidden />
+            <main className="tracker-shell">
+                <header className="tracker-header">
+                    <div className="tracker-heading">
+                        <span className="tracker-eyebrow">
+                            <Sparkles aria-hidden /> Job search control centre
+                        </span>
+                        <h1 className="tracker-title">Track it. Tweak it. Win the offer.</h1>
+                        <p className="tracker-subtitle">
+                            Keep momentum across every stage of your search with a kanban board that matches the app’s glassy
+                            aesthetic.
+                        </p>
+                    </div>
+                    <div className="tracker-utilities">
+                        <div className="tracker-search">
+                            <Search aria-hidden />
+                            <input
+                                type="search"
+                                value={searchQuery}
+                                onChange={(event) => setSearchQuery(event.target.value)}
+                                placeholder="Search role, company or location"
+                                aria-label="Search jobs"
+                            />
+                        </div>
+                        <VoiceControl jobs={jobs} onMove={moveJob} />
+                    </div>
+                </header>
+
+                <div className="tracker-filter-bar">
+                    <div className="tracker-filter-label">
+                        <ListFilter aria-hidden />
+                        <span>Filter by stage</span>
+                    </div>
+                    <div className="tracker-filter-buttons">
+                        <button
+                            type="button"
+                            className={`tracker-chip${selectedStage === null ? " tracker-chip--active" : ""}`}
+                            onClick={() => setSelectedStage(null)}
+                        >
+                            All <span className="tracker-chip__count">{jobs.length}</span>
+                        </button>
+                        {STAGES.map((stage) => (
+                            <button
+                                key={stage.key}
+                                type="button"
+                                className={`tracker-chip${selectedStage === stage.key ? " tracker-chip--active" : ""}`}
+                                onClick={() => setSelectedStage(stage.key)}
+                            >
+                                {stage.label} <span className="tracker-chip__count">{stageCounts[stage.key]}</span>
+                            </button>
+                        ))}
+                    </div>
+                </div>
+
+                <p className="tracker-visible-count">
+                    Showing <strong>{filteredJobs.length}</strong> of {jobs.length} opportunities
+                </p>
+
+                <section className="tracker-board" aria-label="Job pipeline">
+                    {STAGES.map((stage) => (
+                        <StageColumn
+                            key={stage.key}
+                            stage={stage}
+                            jobs={groupedJobs[stage.key]}
+                            activeId={activeId}
+                            onDrop={handleDrop}
+                            onDragStart={handleDragStart}
+                            onDragEnd={handleDragEnd}
+                            onAdd={stage.key === "WISHLIST" ? handleAddJob : undefined}
+                        />
+                    ))}
+                </section>
+            </main>
+        </div>
+    );
+};
+
+export default TrackerPage;

--- a/src/app/tracker/components/JobCard.tsx
+++ b/src/app/tracker/components/JobCard.tsx
@@ -1,0 +1,59 @@
+import { Calendar, Clock, GripVertical, MapPin, MessageSquare, Star } from "lucide-react";
+import type { DragEvent } from "react";
+import type { JobItem } from "../data";
+import { daysSince, formatDisplayDate } from "../utils";
+
+interface JobCardProps {
+    job: JobItem;
+    isDragging: boolean;
+    onDragStart: (id: string, event: DragEvent<HTMLDivElement>) => void;
+    onDragEnd: () => void;
+}
+
+const JobCard = ({ job, isDragging, onDragStart, onDragEnd }: JobCardProps) => {
+    return (
+        <div
+            className={`job-card${isDragging ? " job-card--dragging" : ""}`}
+            draggable
+            onDragStart={(event) => onDragStart(job.id, event)}
+            onDragEnd={onDragEnd}
+        >
+            <header className="job-card__header">
+                <div className="job-card__title">
+                    <GripVertical className="job-card__drag-handle" aria-hidden />
+                    <div>
+                        <h3 className="job-card__role">{job.role}</h3>
+                        <p className="job-card__company">{job.company}</p>
+                    </div>
+                </div>
+                {job.isSaved && <Star className="job-card__saved" aria-hidden />}
+            </header>
+
+            <div className="job-card__meta">
+                <span className="job-card__meta-item">
+                    <MapPin aria-hidden />
+                    {job.location}
+                </span>
+                <span className="job-card__meta-item">
+                    <Clock aria-hidden />
+                    {daysSince(job.appliedDate)}
+                </span>
+            </div>
+
+            <footer className="job-card__footer">
+                <span className="job-card__date">
+                    <Calendar aria-hidden />
+                    {formatDisplayDate(job.appliedDate)}
+                </span>
+                {job.notes > 0 && (
+                    <span className="job-card__notes">
+                        <MessageSquare aria-hidden />
+                        {job.notes}
+                    </span>
+                )}
+            </footer>
+        </div>
+    );
+};
+
+export default JobCard;

--- a/src/app/tracker/components/StageColumn.tsx
+++ b/src/app/tracker/components/StageColumn.tsx
@@ -1,0 +1,68 @@
+import type { DragEvent } from "react";
+import type { JobItem, JobStage, StageDefinition } from "../data";
+import JobCard from "./JobCard";
+
+interface StageColumnProps {
+    stage: StageDefinition;
+    jobs: JobItem[];
+    activeId: string | null;
+    onDrop: (stage: JobStage, event: DragEvent<HTMLDivElement>) => void;
+    onDragStart: (id: string, event: DragEvent<HTMLDivElement>) => void;
+    onDragEnd: () => void;
+    onAdd?: () => void;
+}
+
+const StageColumn = ({ stage, jobs, activeId, onDrop, onDragStart, onDragEnd, onAdd }: StageColumnProps) => {
+    return (
+        <section
+            className="stage-column"
+            data-stage={stage.key}
+            style={{
+                borderColor: stage.accent,
+                backgroundColor: stage.background,
+            }}
+            onDragOver={(event) => event.preventDefault()}
+            onDrop={(event) => {
+                event.preventDefault();
+                onDrop(stage.key, event);
+            }}
+        >
+            <header className="stage-column__header">
+                <div>
+                    <p className="stage-column__label" style={{ color: stage.accent }}>
+                        {stage.label}
+                    </p>
+                    <p className="stage-column__description">{stage.description}</p>
+                </div>
+                <div className="stage-column__count" style={{ color: stage.accent }}>
+                    {jobs.length}
+                </div>
+                {stage.key === "WISHLIST" && onAdd && (
+                    <button type="button" className="stage-column__add" onClick={onAdd} aria-label="Add job to wishlist">
+                        +
+                    </button>
+                )}
+            </header>
+
+            <div className="stage-column__content">
+                {jobs.map((job) => (
+                    <JobCard
+                        key={job.id}
+                        job={job}
+                        isDragging={activeId === job.id}
+                        onDragStart={onDragStart}
+                        onDragEnd={onDragEnd}
+                    />
+                ))}
+                {jobs.length === 0 && (
+                    <div className="stage-column__empty">
+                        <p>Drop a card here</p>
+                        <span>or say “Move [job] to {stage.label}”</span>
+                    </div>
+                )}
+            </div>
+        </section>
+    );
+};
+
+export default StageColumn;

--- a/src/app/tracker/components/VoiceControl.tsx
+++ b/src/app/tracker/components/VoiceControl.tsx
@@ -1,0 +1,152 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { Mic, MicOff } from "lucide-react";
+import type { JobItem, JobStage } from "../data";
+import { findJobByText } from "../utils";
+
+interface VoiceControlProps {
+    jobs: JobItem[];
+    onMove: (jobId: string, stage: JobStage) => void;
+}
+
+type RecognitionInstance = {
+    lang: string;
+    interimResults: boolean;
+    maxAlternatives: number;
+    start: () => void;
+    stop: () => void;
+    abort: () => void;
+    onresult: ((event: { results: Array<{ 0: { transcript: string } }> }) => void) | null;
+    onerror: ((event: unknown) => void) | null;
+    onspeechend: (() => void) | null;
+};
+
+type RecognitionCtor = new () => RecognitionInstance;
+
+type StageAlias = {
+    label: string;
+    stage: JobStage;
+};
+
+const aliases: StageAlias[] = [
+    { label: "wishlist", stage: "WISHLIST" },
+    { label: "applied", stage: "APPLIED" },
+    { label: "interview", stage: "INTERVIEW" },
+    { label: "offer", stage: "OFFER" },
+    { label: "rejected", stage: "REJECTED" },
+];
+
+const VoiceControl = ({ jobs, onMove }: VoiceControlProps) => {
+    const [listening, setListening] = useState(false);
+    const [status, setStatus] = useState<string>("Give a quick voice command");
+    const recognitionRef = useRef<RecognitionInstance | null>(null);
+
+    const recognitionSupported = useMemo(() => {
+        if (typeof window === "undefined") return false;
+        const speechWindow = window as typeof window & {
+            SpeechRecognition?: RecognitionCtor;
+            webkitSpeechRecognition?: RecognitionCtor;
+        };
+        return Boolean(speechWindow.SpeechRecognition || speechWindow.webkitSpeechRecognition);
+    }, []);
+
+    const resolveStage = useCallback((input: string): JobStage | null => {
+        const lower = input.toLowerCase();
+        const match = aliases.find((alias) => lower.includes(alias.label));
+        return match?.stage ?? null;
+    }, []);
+
+    const processCommand = useCallback(
+        (phrase: string) => {
+            if (!phrase.trim()) return;
+            const job = findJobByText(jobs, phrase);
+            const stage = resolveStage(phrase);
+
+            if (job && stage) {
+                onMove(job.id, stage);
+                setStatus(`Moved ${job.role} to ${stage.toLowerCase()}`);
+            } else if (!job) {
+                setStatus("Could not recognise the job in that command");
+            } else {
+                setStatus("I heard you, but could not find the stage");
+            }
+        },
+        [jobs, onMove, resolveStage]
+    );
+
+    useEffect(() => {
+        if (!recognitionSupported || typeof window === "undefined") return;
+        const speechWindow = window as typeof window & {
+            SpeechRecognition?: RecognitionCtor;
+            webkitSpeechRecognition?: RecognitionCtor;
+        };
+        const ctor = speechWindow.SpeechRecognition || speechWindow.webkitSpeechRecognition;
+        if (!ctor) return;
+        const recognition = new ctor();
+        recognition.lang = "en-US";
+        recognition.interimResults = false;
+        recognition.maxAlternatives = 1;
+        recognition.onresult = (event) => {
+            const transcript = event.results[0]?.[0]?.transcript;
+            if (transcript) {
+                processCommand(transcript);
+            }
+            setListening(false);
+        };
+        recognition.onerror = () => {
+            setStatus("Voice recognition error. Try again?");
+            setListening(false);
+        };
+        recognition.onspeechend = () => {
+            recognition.stop();
+        };
+
+        recognitionRef.current = recognition;
+
+        return () => {
+            recognition.stop();
+            recognitionRef.current = null;
+        };
+    }, [processCommand, recognitionSupported]);
+
+    const manualCommand = () => {
+        if (typeof window === "undefined") return;
+        const command = window.prompt("Try something like 'Move Linear to interview'");
+        if (command) {
+            processCommand(command);
+        } else {
+            setStatus("No command provided");
+        }
+    };
+
+    const toggleListening = () => {
+        if (!recognitionSupported || !recognitionRef.current) {
+            setStatus("Voice input unavailable. Enter a quick command instead.");
+            manualCommand();
+            return;
+        }
+
+        if (listening) {
+            recognitionRef.current.stop();
+            setListening(false);
+            return;
+        }
+
+        recognitionRef.current.start();
+        setStatus("Listening... say 'Move [job] to [stage]'");
+        setListening(true);
+    };
+
+    return (
+        <div className="voice-control">
+            <button type="button" className={`voice-control__button${listening ? " voice-control__button--active" : ""}`} onClick={toggleListening}>
+                {listening ? <MicOff aria-hidden /> : <Mic aria-hidden />}
+                <span>{listening ? "Listening" : "Voice"}</span>
+            </button>
+            <p className="voice-control__status">{status}</p>
+        </div>
+    );
+};
+
+export default VoiceControl;

--- a/src/app/tracker/data.ts
+++ b/src/app/tracker/data.ts
@@ -1,0 +1,102 @@
+export type JobStage = "WISHLIST" | "APPLIED" | "INTERVIEW" | "OFFER" | "REJECTED";
+
+export interface StageDefinition {
+    key: JobStage;
+    label: string;
+    accent: string;
+    background: string;
+    description: string;
+}
+
+export interface JobItem {
+    id: string;
+    role: string;
+    company: string;
+    location: string;
+    stage: JobStage;
+    appliedDate: string;
+    notes: number;
+    isSaved: boolean;
+    logoUrl?: string;
+}
+
+export const STAGES: StageDefinition[] = [
+    {
+        key: "WISHLIST",
+        label: "Wishlist",
+        accent: "#c4b5fd",
+        background: "rgba(129, 140, 248, 0.12)",
+        description: "Roles that have caught your eye",
+    },
+    {
+        key: "APPLIED",
+        label: "Applied",
+        accent: "#60a5fa",
+        background: "rgba(96, 165, 250, 0.12)",
+        description: "Applications submitted and awaiting response",
+    },
+    {
+        key: "INTERVIEW",
+        label: "Interview",
+        accent: "#fbbf24",
+        background: "rgba(251, 191, 36, 0.12)",
+        description: "In conversation with the team",
+    },
+    {
+        key: "OFFER",
+        label: "Offer",
+        accent: "#34d399",
+        background: "rgba(52, 211, 153, 0.14)",
+        description: "Offers on the table to review",
+    },
+    {
+        key: "REJECTED",
+        label: "Rejected",
+        accent: "#f87171",
+        background: "rgba(248, 113, 113, 0.1)",
+        description: "Roles that didn\'t work out",
+    },
+];
+
+export const INITIAL_JOBS: JobItem[] = [
+    {
+        id: "1",
+        role: "Senior Product Manager",
+        company: "Linear",
+        location: "San Francisco, CA",
+        stage: "INTERVIEW",
+        appliedDate: "2024-01-15",
+        notes: 2,
+        isSaved: true,
+    },
+    {
+        id: "2",
+        role: "Frontend Engineer",
+        company: "Vercel",
+        location: "Remote",
+        stage: "APPLIED",
+        appliedDate: "2024-01-14",
+        notes: 1,
+        isSaved: false,
+    },
+    {
+        id: "3",
+        role: "Design System Lead",
+        company: "Figma",
+        location: "New York, NY",
+        stage: "WISHLIST",
+        appliedDate: "2024-01-13",
+        notes: 0,
+        isSaved: true,
+    },
+    {
+        id: "4",
+        role: "Full Stack Developer",
+        company: "Supabase",
+        location: "Remote",
+        stage: "OFFER",
+        appliedDate: "2024-01-10",
+        notes: 5,
+        isSaved: false,
+    },
+];

--- a/src/app/tracker/page.tsx
+++ b/src/app/tracker/page.tsx
@@ -1,11 +1,12 @@
 
 
 import { Suspense } from "react";
+import TrackerPage from "./TrackerPage";
 
 export default function Page() {
     return (
         <Suspense fallback={<div />}>
-            <div>Tracker</div>
+            <TrackerPage />
         </Suspense>
     );
 }

--- a/src/app/tracker/tracker.css
+++ b/src/app/tracker/tracker.css
@@ -1,0 +1,452 @@
+.tracker-page {
+    --tracker-bg: hsl(221 64% 6%);
+    --tracker-bg-secondary: hsl(230 60% 10%);
+    --tracker-text: #f8fafc;
+    --tracker-muted: hsla(213, 32%, 80%, 0.75);
+    --tracker-border: hsla(215, 40%, 85%, 0.1);
+    --tracker-glass: hsla(220, 45%, 12%, 0.6);
+    --tracker-chip-bg: hsla(225, 60%, 40%, 0.18);
+    min-height: 100vh;
+    background: radial-gradient(circle at top left, rgba(99, 102, 241, 0.35), transparent 45%),
+        radial-gradient(circle at bottom right, rgba(20, 184, 166, 0.25), transparent 55%), var(--tracker-bg);
+    color: var(--tracker-text);
+}
+
+.tracker-backdrop {
+    position: absolute;
+    inset: 0;
+    background: linear-gradient(135deg, rgba(15, 23, 42, 0.8), rgba(17, 24, 39, 0.6));
+    backdrop-filter: blur(16px);
+    -webkit-backdrop-filter: blur(16px);
+    pointer-events: none;
+}
+
+.tracker-shell {
+    position: relative;
+    max-width: 1200px;
+    margin: 0 auto;
+    padding: 64px 24px 80px;
+    display: grid;
+    gap: 32px;
+}
+
+.tracker-header {
+    display: flex;
+    flex-direction: column;
+    gap: 24px;
+}
+
+.tracker-heading {
+    display: grid;
+    gap: 12px;
+    max-width: 640px;
+}
+
+.tracker-eyebrow {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    font-size: 0.85rem;
+    text-transform: uppercase;
+    letter-spacing: 0.12em;
+    color: var(--tracker-muted);
+    font-weight: 600;
+}
+
+.tracker-eyebrow svg {
+    width: 16px;
+    height: 16px;
+    color: #a855f7;
+}
+
+.tracker-title {
+    font-size: clamp(2rem, 5vw, 2.75rem);
+    margin: 0;
+    font-weight: 700;
+}
+
+.tracker-subtitle {
+    margin: 0;
+    color: var(--tracker-muted);
+    font-size: 1.05rem;
+    line-height: 1.6;
+}
+
+.tracker-utilities {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 16px;
+    align-items: center;
+}
+
+.tracker-search {
+    display: inline-flex;
+    align-items: center;
+    gap: 12px;
+    padding: 12px 16px;
+    border-radius: 999px;
+    background: hsla(220, 60%, 10%, 0.65);
+    border: 1px solid var(--tracker-border);
+    backdrop-filter: blur(14px);
+    -webkit-backdrop-filter: blur(14px);
+    min-width: 260px;
+}
+
+.tracker-search svg {
+    width: 18px;
+    height: 18px;
+    color: var(--tracker-muted);
+}
+
+.tracker-search input {
+    background: transparent;
+    border: none;
+    outline: none;
+    color: var(--tracker-text);
+    font-size: 0.95rem;
+    width: 100%;
+}
+
+.tracker-search input::placeholder {
+    color: rgba(248, 250, 252, 0.5);
+}
+
+.tracker-filter-bar {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 16px;
+    justify-content: space-between;
+}
+
+.tracker-filter-label {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    color: var(--tracker-muted);
+    font-weight: 600;
+}
+
+.tracker-filter-label svg {
+    width: 18px;
+    height: 18px;
+}
+
+.tracker-filter-buttons {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 12px;
+}
+
+.tracker-chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    padding: 8px 16px;
+    border-radius: 999px;
+    border: 1px solid transparent;
+    background: hsla(220, 45%, 14%, 0.6);
+    color: var(--tracker-muted);
+    font-size: 0.9rem;
+    cursor: pointer;
+    transition: all 0.2s ease;
+}
+
+.tracker-chip__count {
+    padding: 0 6px;
+    border-radius: 999px;
+    background: hsla(220, 40%, 50%, 0.25);
+    color: var(--tracker-text);
+    font-size: 0.75rem;
+}
+
+.tracker-chip:hover,
+.tracker-chip:focus-visible {
+    border-color: var(--tracker-border);
+    color: var(--tracker-text);
+}
+
+.tracker-chip--active {
+    background: var(--tracker-chip-bg);
+    color: var(--tracker-text);
+    border-color: hsla(225, 80%, 70%, 0.65);
+    box-shadow: 0 10px 30px rgba(79, 70, 229, 0.25);
+}
+
+.tracker-visible-count {
+    color: var(--tracker-muted);
+    font-size: 0.95rem;
+}
+
+.tracker-visible-count strong {
+    color: var(--tracker-text);
+}
+
+.tracker-board {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 20px;
+}
+
+.stage-column {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+    border-radius: 18px;
+    border: 1px solid var(--tracker-border);
+    padding: 20px;
+    min-height: 520px;
+    background: var(--tracker-glass);
+    backdrop-filter: blur(18px);
+    -webkit-backdrop-filter: blur(18px);
+    box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.02);
+}
+
+.stage-column__header {
+    display: flex;
+    align-items: flex-start;
+    gap: 12px;
+}
+
+.stage-column__label {
+    font-weight: 700;
+    margin: 0;
+    font-size: 1rem;
+    letter-spacing: 0.04em;
+}
+
+.stage-column__description {
+    margin: 4px 0 0;
+    color: var(--tracker-muted);
+    font-size: 0.82rem;
+}
+
+.stage-column__count {
+    margin-left: auto;
+    font-weight: 700;
+    font-size: 1.25rem;
+}
+
+.stage-column__add {
+    margin-left: 4px;
+    width: 32px;
+    height: 32px;
+    border-radius: 50%;
+    border: 1px solid var(--tracker-border);
+    background: rgba(99, 102, 241, 0.2);
+    color: var(--tracker-text);
+    cursor: pointer;
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.stage-column__add:hover,
+.stage-column__add:focus-visible {
+    transform: translateY(-1px);
+    box-shadow: 0 12px 25px rgba(99, 102, 241, 0.35);
+}
+
+.stage-column__content {
+    display: grid;
+    gap: 16px;
+    flex: 1;
+}
+
+.stage-column__empty {
+    border: 2px dashed rgba(148, 163, 184, 0.25);
+    border-radius: 16px;
+    padding: 28px 16px;
+    text-align: center;
+    color: var(--tracker-muted);
+    font-size: 0.9rem;
+    display: grid;
+    gap: 8px;
+    align-content: center;
+}
+
+.stage-column__empty span {
+    font-size: 0.8rem;
+    opacity: 0.8;
+}
+
+.job-card {
+    border-radius: 18px;
+    padding: 18px;
+    border: 1px solid rgba(148, 163, 184, 0.12);
+    background: hsla(220, 45%, 15%, 0.85);
+    backdrop-filter: blur(14px);
+    -webkit-backdrop-filter: blur(14px);
+    display: grid;
+    gap: 12px;
+    cursor: grab;
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.job-card:active {
+    cursor: grabbing;
+}
+
+.job-card:hover {
+    transform: translateY(-3px);
+    box-shadow: 0 18px 35px rgba(14, 165, 233, 0.18);
+}
+
+.job-card--dragging {
+    opacity: 0.9;
+    transform: rotate(1deg) scale(1.03);
+    box-shadow: 0 22px 45px rgba(59, 130, 246, 0.35);
+}
+
+.job-card__header {
+    display: flex;
+    justify-content: space-between;
+    gap: 16px;
+}
+
+.job-card__title {
+    display: flex;
+    align-items: flex-start;
+    gap: 12px;
+}
+
+.job-card__drag-handle {
+    width: 16px;
+    height: 16px;
+    color: rgba(148, 163, 184, 0.4);
+    margin-top: 4px;
+}
+
+.job-card__role {
+    margin: 0;
+    font-size: 1rem;
+    font-weight: 600;
+}
+
+.job-card__company {
+    margin: 2px 0 0;
+    font-size: 0.85rem;
+    color: var(--tracker-muted);
+}
+
+.job-card__saved {
+    width: 18px;
+    height: 18px;
+    color: #fbbf24;
+}
+
+.job-card__meta {
+    display: flex;
+    justify-content: space-between;
+    color: var(--tracker-muted);
+    font-size: 0.82rem;
+}
+
+.job-card__meta-item {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+}
+
+.job-card__meta svg,
+.job-card__footer svg {
+    width: 14px;
+    height: 14px;
+    color: rgba(148, 163, 184, 0.65);
+}
+
+.job-card__footer {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    font-size: 0.8rem;
+    color: var(--tracker-muted);
+    border-top: 1px solid rgba(148, 163, 184, 0.1);
+    padding-top: 12px;
+}
+
+.job-card__notes {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 4px 8px;
+    border-radius: 999px;
+    background: rgba(59, 130, 246, 0.18);
+    color: var(--tracker-text);
+    font-size: 0.75rem;
+}
+
+.voice-control {
+    display: grid;
+    gap: 8px;
+    min-width: 180px;
+}
+
+.voice-control__button {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    padding: 10px 16px;
+    border-radius: 999px;
+    border: 1px solid var(--tracker-border);
+    background: rgba(14, 116, 144, 0.25);
+    color: var(--tracker-text);
+    cursor: pointer;
+    transition: background 0.2s ease, box-shadow 0.2s ease;
+}
+
+.voice-control__button svg {
+    width: 16px;
+    height: 16px;
+}
+
+.voice-control__button:hover,
+.voice-control__button:focus-visible {
+    box-shadow: 0 14px 28px rgba(45, 212, 191, 0.28);
+}
+
+.voice-control__button--active {
+    background: rgba(45, 212, 191, 0.35);
+}
+
+.voice-control__status {
+    margin: 0;
+    font-size: 0.75rem;
+    color: var(--tracker-muted);
+}
+
+@media (max-width: 900px) {
+    .tracker-shell {
+        padding: 48px 18px 64px;
+    }
+
+    .tracker-utilities {
+        flex-direction: column;
+        align-items: stretch;
+    }
+
+    .tracker-search {
+        width: 100%;
+    }
+
+    .voice-control {
+        width: 100%;
+    }
+
+    .tracker-board {
+        grid-template-columns: 1fr;
+    }
+
+    .stage-column {
+        min-height: auto;
+    }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    *,
+    *::before,
+    *::after {
+        animation-duration: 0.01ms !important;
+        animation-iteration-count: 1 !important;
+        transition-duration: 0.01ms !important;
+        scroll-behavior: auto !important;
+    }
+}

--- a/src/app/tracker/utils.ts
+++ b/src/app/tracker/utils.ts
@@ -1,0 +1,55 @@
+import type { JobItem, JobStage } from "./data";
+
+export const filterJobs = (jobs: JobItem[], query: string, stage: JobStage | null) => {
+    const normalisedQuery = query.trim().toLowerCase();
+    return jobs.filter((job) => {
+        const matchesQuery =
+            !normalisedQuery ||
+            job.role.toLowerCase().includes(normalisedQuery) ||
+            job.company.toLowerCase().includes(normalisedQuery) ||
+            job.location.toLowerCase().includes(normalisedQuery);
+        const matchesStage = !stage || job.stage === stage;
+        return matchesQuery && matchesStage;
+    });
+};
+
+export const groupJobsByStage = (jobs: JobItem[]) => {
+    return jobs.reduce<Record<JobStage, JobItem[]>>(
+        (acc, job) => {
+            acc[job.stage].push(job);
+            return acc;
+        },
+        {
+            WISHLIST: [],
+            APPLIED: [],
+            INTERVIEW: [],
+            OFFER: [],
+            REJECTED: [],
+        }
+    );
+};
+
+export const formatDisplayDate = (date: string) => {
+    const parsed = new Date(date);
+    if (Number.isNaN(parsed.getTime())) return "Unknown";
+    return parsed.toLocaleDateString("en-US", {
+        month: "short",
+        day: "numeric",
+    });
+};
+
+export const daysSince = (date: string) => {
+    const parsed = new Date(date);
+    if (Number.isNaN(parsed.getTime())) return "-";
+    const diff = Date.now() - parsed.getTime();
+    const days = Math.max(0, Math.floor(diff / (1000 * 60 * 60 * 24)));
+    return `${days}d`;
+};
+
+export const findJobByText = (jobs: JobItem[], phrase: string) => {
+    const lower = phrase.toLowerCase();
+    return (
+        jobs.find((job) => lower.includes(job.role.toLowerCase())) ||
+        jobs.find((job) => lower.includes(job.company.toLowerCase()))
+    );
+};


### PR DESCRIPTION
## Summary
- replace the tracker route with a kanban board that supports search, filtering, drag and drop, and quick add actions
- extract reusable data helpers, voice control, and presentation components for tracker jobs
- apply a glassmorphism-inspired theme and register tracker styles for consistent visuals

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68de7ddbb4b08325bd35d91d2211965f