### PR TITLE
Implement tracker API integration

### DIFF
--- a/src/app/login/AuthPage.tsx
+++ b/src/app/login/AuthPage.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable */
 "use client";
 
 import { useState, useRef, useEffect, type FormEvent } from "react";

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,5 +1,3 @@
-/* eslint-disable */
-
 import { Suspense } from "react";
 import AuthPage from "./AuthPage";
 

--- a/src/app/tracker/TrackerPage.tsx
+++ b/src/app/tracker/TrackerPage.tsx
@@ -1,11 +1,41 @@
 "use client";
 
-import { useMemo, useState, type DragEvent } from "react";
+import { useCallback, useEffect, useMemo, useState, type DragEvent } from "react";
 import { Search, Sparkles } from "lucide-react";
 import StageColumn from "./components/StageColumn";
 import VoiceControl from "./components/VoiceControl";
 import { INITIAL_JOBS, STAGES, type JobItem, type JobStage } from "./data";
 import { filterJobs, groupJobsByStage } from "./utils";
+import {
+    createJob as createJobRequest,
+    listJobs as listJobsRequest,
+    updateJob as updateJobRequest,
+    type ApiJob,
+} from "@/services/tracker.service";
+
+const isJobStage = (value: string | null | undefined): value is JobStage =>
+    value === "WISHLIST" || value === "APPLIED" || value === "INTERVIEW" || value === "OFFER" || value === "ARCHIVED";
+
+const fallbackAppliedDate = (job: ApiJob) => {
+    const candidates = [job.appliedOn, job.updatedAt, job.createdAt].filter((value): value is string => Boolean(value));
+    const resolved = candidates.find((value) => !Number.isNaN(new Date(value).getTime()));
+    if (resolved) {
+        return resolved.split("T")[0];
+    }
+    return new Date().toISOString().split("T")[0];
+};
+
+const toJobItem = (job: ApiJob): JobItem => ({
+    id: job.id,
+    role: job.title ?? "Untitled role",
+    company: job.company ?? "Unknown company",
+    location: job.location ?? "Remote",
+    stage: isJobStage(job.stage) ? job.stage : "WISHLIST",
+    appliedDate: fallbackAppliedDate(job),
+    notes: typeof job.notesCount === "number" ? job.notesCount : 0,
+    isSaved: job.priority === "starred" || job.priority === "STARRED" || job.isSaved === true,
+    logoUrl: job.logoUrl ?? undefined,
+});
 
 const TrackerPage = () => {
     const [jobs, setJobs] = useState<JobItem[]>(INITIAL_JOBS);
@@ -35,15 +65,45 @@ const TrackerPage = () => {
         );
     }, [jobs]);
 
-    const moveJob = (jobId: string, stage: JobStage) => {
-        setJobs((prev) =>
-            prev.map((job) =>
-                job.id === jobId
-                    ? { ...job, stage, appliedDate: new Date().toISOString().split("T")[0] }
-                    : job
-            )
-        );
-    };
+    const fetchJobs = useCallback(async () => {
+        try {
+            const { jobs: fetchedJobs } = await listJobsRequest({ archived: false, limit: 100 });
+            if (Array.isArray(fetchedJobs)) {
+                setJobs(fetchedJobs.map(toJobItem));
+            } else {
+                setJobs([]);
+            }
+        } catch (error) {
+            console.error("Failed to load jobs", error);
+        }
+    }, []);
+
+    useEffect(() => {
+        void fetchJobs();
+    }, [fetchJobs]);
+
+    const moveJob = useCallback((jobId: string, stage: JobStage) => {
+        void (async () => {
+            try {
+                const updated = await updateJobRequest(jobId, { stage });
+                if (updated) {
+                    setJobs((prev) =>
+                        prev.map((job) => (job.id === jobId ? toJobItem(updated) : job))
+                    );
+                    return;
+                }
+            } catch (error) {
+                console.error("Failed to update job", error);
+            }
+            setJobs((prev) =>
+                prev.map((job) =>
+                    job.id === jobId
+                        ? { ...job, stage, appliedDate: new Date().toISOString().split("T")[0] }
+                        : job
+                )
+            );
+        })();
+    }, []);
 
     const handleDragStart = (id: string, event: DragEvent<HTMLDivElement>) => {
         event.dataTransfer?.setData("text/plain", id);
@@ -69,18 +129,30 @@ const TrackerPage = () => {
         const company = window.prompt("Which company is it for?") || "Unknown company";
         const location = window.prompt("Where is the role located?") || "Remote";
 
-        const newJob: JobItem = {
-            id: `${Date.now()}`,
-            role,
-            company,
-            location,
-            stage: "WISHLIST",
-            appliedDate: new Date().toISOString().split("T")[0],
-            notes: 0,
-            isSaved: false,
-        };
+        void (async () => {
+            try {
+                const created = await createJobRequest({ title: role, company, location });
+                if (created) {
+                    setJobs((prev) => [toJobItem(created), ...prev]);
+                    return;
+                }
+            } catch (error) {
+                console.error("Failed to create job", error);
+            }
 
-        setJobs((prev) => [newJob, ...prev]);
+            const fallback: JobItem = {
+                id: `${Date.now()}`,
+                role,
+                company,
+                location,
+                stage: "WISHLIST",
+                appliedDate: new Date().toISOString().split("T")[0],
+                notes: 0,
+                isSaved: false,
+            };
+
+            setJobs((prev) => [fallback, ...prev]);
+        })();
     };
 
     return (

--- a/src/services/tracker.service.ts
+++ b/src/services/tracker.service.ts
@@ -1,0 +1,217 @@
+import { http } from "@/lib/http";
+import type { JobStage } from "@/app/tracker/data";
+
+export type ApiJobStage = JobStage;
+
+export interface ApiJob {
+  id: string;
+  title: string;
+  company: string;
+  location?: string | null;
+  stage: ApiJobStage;
+  priority?: string | null;
+  appliedOn?: string | null;
+  archived?: boolean;
+  notesCount?: number;
+  isSaved?: boolean;
+  logoUrl?: string | null;
+  createdAt?: string;
+  updatedAt?: string;
+  [key: string]: unknown;
+}
+
+export interface ApiJobComment {
+  id: string;
+  text: string;
+  createdAt: string;
+  updatedAt?: string;
+  authorName?: string;
+  [key: string]: unknown;
+}
+
+export interface ApiJobAuditEvent {
+  id: string;
+  type: string;
+  createdAt: string;
+  actor?: string | null;
+  payload?: Record<string, unknown>;
+  [key: string]: unknown;
+}
+
+type Params = Record<string, string | number | boolean | undefined>;
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null;
+
+const isApiJob = (value: unknown): value is ApiJob =>
+  isRecord(value) && typeof value.id === "string" && typeof value.stage === "string";
+
+const unwrapJob = (value: unknown): ApiJob | null => {
+  if (isApiJob(value)) {
+    return value;
+  }
+  if (isRecord(value)) {
+    if (isApiJob(value.job)) {
+      return value.job;
+    }
+    if (isApiJob(value.data)) {
+      return value.data as ApiJob;
+    }
+  }
+  return null;
+};
+
+const unwrapCollection = <T>(value: unknown, key: string): T[] | null => {
+  if (Array.isArray(value)) {
+    return value as T[];
+  }
+  if (isRecord(value)) {
+    const direct = value[key];
+    if (Array.isArray(direct)) {
+      return direct as T[];
+    }
+    if (Array.isArray(value.data)) {
+      return value.data as T[];
+    }
+    if (isRecord(value.data) && Array.isArray(value.data[key])) {
+      return value.data[key] as T[];
+    }
+  }
+  return null;
+};
+
+const unwrapJobs = (value: unknown): ApiJob[] => {
+  return unwrapCollection<ApiJob>(value, "jobs")?.filter(isApiJob) ?? [];
+};
+
+const unwrapComments = (value: unknown): ApiJobComment[] => {
+  const comments = unwrapCollection<ApiJobComment>(value, "comments") ?? [];
+  return comments.filter((comment) => typeof comment.id === "string" && typeof comment.text === "string");
+};
+
+const unwrapAuditEvents = (value: unknown): ApiJobAuditEvent[] => {
+  const events = unwrapCollection<ApiJobAuditEvent>(value, "audit") ?? [];
+  return events.filter((event) => typeof event.id === "string" && typeof event.type === "string");
+};
+
+const extractCursor = (value: unknown): string | undefined => {
+  if (!isRecord(value)) return undefined;
+  if (typeof value.nextCursor === "string") return value.nextCursor;
+  if (typeof value.cursor === "string") return value.cursor;
+  if (isRecord(value.page) && typeof value.page.next === "string") {
+    return value.page.next;
+  }
+  if (isRecord(value.data)) {
+    return extractCursor(value.data);
+  }
+  return undefined;
+};
+
+const buildParams = (params?: Params): Params | undefined => {
+  if (!params) return undefined;
+  return Object.keys(params).reduce<Params>((acc, key) => {
+    const value = params[key];
+    if (value !== undefined) {
+      acc[key] = value;
+    }
+    return acc;
+  }, {});
+};
+
+export const listJobs = async (params?: {
+  stage?: ApiJobStage | null;
+  archived?: boolean;
+  limit?: number;
+  cursor?: string;
+}) => {
+  const query = buildParams({
+    stage: params?.stage ?? undefined,
+    archived: params?.archived,
+    limit: params?.limit,
+    cursor: params?.cursor,
+  });
+  const { data } = await http.get("/core/jobs", { params: query });
+  return {
+    jobs: unwrapJobs(data),
+    nextCursor: extractCursor(data) ?? null,
+    raw: data,
+  };
+};
+
+export const getJob = async (id: string) => {
+  const { data } = await http.get(`/core/jobs/${id}`);
+  return unwrapJob(data);
+};
+
+export const createJob = async (body: { title: string; company: string; location?: string | null }) => {
+  const { data } = await http.post("/core/jobs", body);
+  return unwrapJob(data);
+};
+
+export const updateJob = async (
+  id: string,
+  body: Partial<{ title: string; company: string; location: string | null; stage: ApiJobStage; priority: string; appliedOn: string }>,
+) => {
+  const { data } = await http.patch(`/core/jobs/${id}`, body);
+  return unwrapJob(data);
+};
+
+export const archiveJob = async (id: string) => {
+  const { data } = await http.post(`/core/jobs/${id}/archive`);
+  return unwrapJob(data);
+};
+
+export const restoreJob = async (id: string) => {
+  const { data } = await http.post(`/core/jobs/${id}/restore`);
+  return unwrapJob(data);
+};
+
+export const addJobComment = async (id: string, body: { text: string }) => {
+  const { data } = await http.post(`/core/jobs/${id}/comments`, body);
+  return unwrapCollection<ApiJobComment>(data, "comment")?.[0] ?? unwrapComments(data)[0] ?? null;
+};
+
+export const listJobComments = async (
+  id: string,
+  params?: { limit?: number; cursor?: string },
+) => {
+  const query = buildParams(params);
+  const { data } = await http.get(`/core/jobs/${id}/comments`, { params: query });
+  return {
+    comments: unwrapComments(data),
+    nextCursor: extractCursor(data) ?? null,
+    raw: data,
+  };
+};
+
+export const listJobAuditTrail = async (
+  id: string,
+  params?: { limit?: number; cursor?: string },
+) => {
+  const query = buildParams(params);
+  const { data } = await http.get(`/core/jobs/${id}/audit`, { params: query });
+  return {
+    events: unwrapAuditEvents(data),
+    nextCursor: extractCursor(data) ?? null,
+    raw: data,
+  };
+};
+
+export const applyCommand = async (body: {
+  channel: string;
+  transcript: string;
+  requestId?: string;
+}) => {
+  const { data } = await http.post("/core/commands", body);
+  return data;
+};
+
+export const parseLink = async (body: { sourceUrl: string }) => {
+  const { data } = await http.post("/core/internal/parser/link", body);
+  return data;
+};
+
+export const parseCommand = async (body: { transcript: string }) => {
+  const { data } = await http.post("/core/internal/commands/parse", body);
+  return data;
+};


### PR DESCRIPTION
## Summary
- add a tracker service that wraps InterviewEasy core endpoints for jobs, comments, audit, and commands
- integrate the tracker board with the new service for loading, creating, and moving jobs, with safe fallbacks when API data is unavailable
- remove stale eslint disable directives from login pages so linting passes cleanly

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e2a0d02dac832586670a17b6d76875