### PR TITLE
feat: add reusable ui kit and job modal

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -40,3 +40,197 @@ a {
     color-scheme: dark;
   }
 }
+
+.ui-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  border: none;
+  border-radius: 999px;
+  background: linear-gradient(135deg, #4f46e5, #7c3aed);
+  color: #fff;
+  padding: 0.55rem 1.4rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.15s ease, box-shadow 0.2s ease, opacity 0.2s ease;
+}
+
+.ui-button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.ui-button:not(:disabled):hover {
+  box-shadow: 0 12px 30px rgba(79, 70, 229, 0.25);
+}
+
+.ui-button:not(:disabled):active {
+  transform: scale(0.98);
+}
+
+.ui-input,
+.ui-textarea {
+  width: 100%;
+  border-radius: 12px;
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  background: rgba(15, 23, 42, 0.6);
+  color: #f8fafc;
+  padding: 0.65rem 0.9rem;
+  font-size: 0.95rem;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.ui-input:focus,
+.ui-textarea:focus {
+  outline: none;
+  border-color: rgba(99, 102, 241, 0.8);
+  box-shadow: 0 0 0 3px rgba(99, 102, 241, 0.35);
+}
+
+.ui-label {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: rgba(226, 232, 240, 0.9);
+}
+
+.ui-dialog-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(8, 11, 20, 0.6);
+  backdrop-filter: blur(10px);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1.5rem;
+  z-index: 50;
+}
+
+.ui-dialog-content {
+  width: min(100%, 600px);
+  border-radius: 20px;
+  background: linear-gradient(145deg, rgba(15, 23, 42, 0.92), rgba(30, 41, 59, 0.92));
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  box-shadow: 0 24px 80px rgba(15, 23, 42, 0.35);
+  padding: 1.8rem;
+  color: #e2e8f0;
+}
+
+.ui-dialog-title {
+  font-size: 1.4rem;
+  font-weight: 700;
+  background: linear-gradient(120deg, #a855f7, #60a5fa);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+}
+
+.ui-tabs {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.ui-tabs-list {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0.4rem;
+  background: rgba(15, 23, 42, 0.4);
+  padding: 0.4rem;
+  border-radius: 12px;
+}
+
+.ui-tabs-trigger {
+  border: none;
+  border-radius: 10px;
+  background: transparent;
+  color: rgba(226, 232, 240, 0.8);
+  padding: 0.55rem 0.75rem;
+  font-weight: 600;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.45rem;
+  cursor: pointer;
+  transition: background 0.2s ease, color 0.2s ease;
+}
+
+.ui-tabs-trigger[data-state="active"] {
+  background: rgba(99, 102, 241, 0.15);
+  color: #fff;
+}
+
+.ui-tabs-content {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.ui-toast {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  background: rgba(15, 23, 42, 0.95);
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  border-radius: 14px;
+  padding: 0.85rem 1rem;
+  box-shadow: 0 18px 40px rgba(15, 23, 42, 0.45);
+  color: #e2e8f0;
+}
+
+.ui-toast--destructive {
+  border-color: rgba(248, 113, 113, 0.6);
+}
+
+.ui-toast__title {
+  font-weight: 600;
+  margin-bottom: 0.15rem;
+}
+
+.ui-toast__description {
+  font-size: 0.85rem;
+  color: rgba(226, 232, 240, 0.75);
+}
+
+.ui-toast__close {
+  background: transparent;
+  border: none;
+  color: inherit;
+  font-size: 1.1rem;
+  cursor: pointer;
+}
+
+.ui-toaster {
+  position: fixed;
+  inset-inline-end: 1.5rem;
+  inset-block-start: 1.5rem;
+  display: grid;
+  gap: 0.75rem;
+  z-index: 60;
+}
+
+.ui-tooltip__content {
+  position: absolute;
+  margin-top: 0.5rem;
+  background: rgba(15, 23, 42, 0.95);
+  color: #e2e8f0;
+  padding: 0.45rem 0.6rem;
+  border-radius: 8px;
+  font-size: 0.75rem;
+  box-shadow: 0 12px 30px rgba(15, 23, 42, 0.35);
+}
+
+.ui-toast__content {
+  display: flex;
+  flex-direction: column;
+}
+
+@keyframes ui-pulse {
+  0%,
+  100% {
+    opacity: 0.45;
+  }
+  50% {
+    opacity: 1;
+  }
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
 import "./tracker/tracker.css";
+import { Toaster } from "@/components/ui/toaster";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -27,6 +28,7 @@ export default function RootLayout({
     <html lang="en">
       <body className={`${geistSans.variable} ${geistMono.variable}`}>
         {children}
+        <Toaster />
       </body>
     </html>
   );

--- a/src/app/tracker/components/AddJobModal.tsx
+++ b/src/app/tracker/components/AddJobModal.tsx
@@ -1,0 +1,341 @@
+"use client";
+
+import { useState } from "react";
+import {
+    Dialog,
+    DialogContent,
+    DialogHeader,
+    DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import { Label } from "@/components/ui/label";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { useToast } from "@/components/ui/use-toast";
+import { Building2, ExternalLink, FileText, Link2, Loader2, Mic } from "lucide-react";
+import type { JobStage } from "../data";
+import "./add-job-modal.css";
+
+type RecognitionResult = {
+    isFinal: boolean;
+    0?: { transcript?: string };
+};
+
+interface RecognitionEvent {
+    results: ArrayLike<RecognitionResult>;
+}
+
+interface RecognitionInstance {
+    lang: string;
+    continuous: boolean;
+    interimResults: boolean;
+    start: () => void;
+    stop: () => void;
+    onresult: ((event: RecognitionEvent) => void) | null;
+    onerror: ((event: unknown) => void) | null;
+    onend: (() => void) | null;
+}
+
+type RecognitionConstructor = new () => RecognitionInstance;
+
+interface AddJobModalProps {
+    isOpen: boolean;
+    onClose: () => void;
+    onAddJob: (job: { company: string; role: string; stage: JobStage }) => void;
+}
+
+const stageKeywords: Record<JobStage, string[]> = {
+    WISHLIST: [],
+    APPLIED: ["applied", "sent application", "submitted"],
+    INTERVIEW: ["interview", "phone screen", "meeting"],
+    OFFER: ["offer", "got offer", "received offer"],
+    ARCHIVED: ["rejected", "declined", "turned down"],
+};
+
+const defaultStage: JobStage = "WISHLIST";
+
+const AddJobModal = ({ isOpen, onClose, onAddJob }: AddJobModalProps) => {
+    const { toast } = useToast();
+    const [isLoading, setIsLoading] = useState(false);
+    const [jobUrl, setJobUrl] = useState("");
+    const [jobText, setJobText] = useState("");
+    const [isRecording, setIsRecording] = useState(false);
+
+    const resolveStage = (content: string): JobStage => {
+        const lower = content.toLowerCase();
+        for (const [stage, keywords] of Object.entries(stageKeywords) as Array<[JobStage, string[]]>) {
+            if (keywords.some((keyword) => lower.includes(keyword))) {
+                return stage;
+            }
+        }
+        return defaultStage;
+    };
+
+    const addJobAndClose = (job: { company: string; role: string; stage: JobStage }, message: string) => {
+        onAddJob(job);
+        toast({ title: "Job Added! 🎉", description: message });
+        setIsLoading(false);
+        setIsRecording(false);
+        setJobText("");
+        setJobUrl("");
+        onClose();
+    };
+
+    const handleLinkSubmit = async () => {
+        if (!jobUrl.trim()) return;
+        setIsLoading(true);
+        try {
+            const url = new URL(jobUrl);
+            const company = url.hostname.replace(/^www\./, "");
+            const role = url.pathname.split("/").filter(Boolean).pop() ?? "Role";
+            const cleanedRole = role.replace(/[-_]/g, " ").replace(/\d+/g, "").trim() || "Role";
+            addJobAndClose(
+                { company, role: cleanedRole, stage: defaultStage },
+                "Successfully parsed job from link"
+            );
+        } catch (error) {
+            console.error("Failed to parse job link", error);
+            toast({
+                title: "Unable to parse link",
+                description: "Enter a valid job posting URL",
+                variant: "destructive",
+            });
+            setIsLoading(false);
+        }
+    };
+
+    const handleTextSubmit = async () => {
+        if (!jobText.trim()) return;
+        setIsLoading(true);
+        const content = jobText.trim();
+        const lines = content.split(/\n|\./).map((line) => line.trim()).filter(Boolean);
+        const headline = lines[0] ?? "Job";
+        const words = headline.split(" at ");
+        const role = words[0]?.trim() || "Role";
+        const company = words[1]?.trim() || "Unknown company";
+        const stage = resolveStage(content);
+        addJobAndClose(
+            { company, role, stage },
+            "Successfully parsed job from text"
+        );
+    };
+
+    const processVoiceJobInput = (transcript: string) => {
+        const cleanInput = transcript.toLowerCase();
+
+        const companyPatterns = [
+            /(?:at|from|to|with)\s+([a-z][a-z\s]+?)(?:\s+(?:as|for|in)|$)/i,
+            /([a-z][a-z\s]+?)(?:\s+(?:as|for|in))/i,
+        ];
+
+        let company = "";
+        for (const pattern of companyPatterns) {
+            const match = cleanInput.match(pattern);
+            if (match && match[1]) {
+                company = match[1].trim();
+                break;
+            }
+        }
+
+        const rolePatterns = [
+            /(?:as|for)\s+([a-z][a-z\s]+?)(?:\s+(?:position|role)|$)/i,
+            /(?:pm|product manager|engineer|developer|analyst|designer|manager)/i,
+        ];
+
+        let role = "";
+        for (const pattern of rolePatterns) {
+            const match = cleanInput.match(pattern);
+            if (!match) continue;
+            if (typeof match === "string") {
+                role = match;
+            } else if (match[1]) {
+                role = match[1];
+            } else if (match[0]) {
+                role = match[0];
+            }
+            break;
+        }
+
+        const stage = resolveStage(cleanInput);
+
+        if (company || role) {
+            const finalCompany = company || "Unknown company";
+            const finalRole = role || "Position";
+            addJobAndClose(
+                { company: finalCompany, role: finalRole, stage },
+                `Added ${finalRole} at ${finalCompany}`
+            );
+        } else {
+            toast({
+                title: "Couldn't parse job info",
+                description: 'Try saying: "Add job at Google as PM position applied"',
+                variant: "destructive",
+            });
+            setIsRecording(false);
+        }
+    };
+
+    const handleVoiceRecord = async () => {
+        if (typeof window === "undefined") return;
+        const speechWindow = window as typeof window & {
+            SpeechRecognition?: RecognitionConstructor;
+            webkitSpeechRecognition?: RecognitionConstructor;
+        };
+
+        const RecognitionCtor: RecognitionConstructor | undefined =
+            speechWindow.SpeechRecognition ?? speechWindow.webkitSpeechRecognition;
+
+        if (!RecognitionCtor) {
+            toast({
+                title: "Not Supported",
+                description: "Speech recognition is not supported in this browser",
+                variant: "destructive",
+            });
+            return;
+        }
+
+        const recognition = new RecognitionCtor();
+        recognition.continuous = false;
+        recognition.interimResults = false;
+        recognition.lang = "en-US";
+
+        recognition.onresult = (event) => {
+            const result = event.results[event.results.length - 1];
+            if (result?.isFinal) {
+                const transcript = result[0]?.transcript ?? "";
+                processVoiceJobInput(transcript);
+            }
+        };
+
+        recognition.onerror = () => {
+            toast({
+                title: "Error",
+                description: "Could not capture voice input",
+                variant: "destructive",
+            });
+            setIsRecording(false);
+        };
+
+        recognition.onend = () => {
+            setIsRecording(false);
+        };
+
+        setIsRecording(true);
+        recognition.start();
+    };
+
+    return (
+        <Dialog open={isOpen} onOpenChange={onClose}>
+            <DialogContent className="add-job__content">
+                <DialogHeader>
+                    <DialogTitle className="add-job__title">Add New Job</DialogTitle>
+                </DialogHeader>
+
+                <Tabs defaultValue="link" className="add-job__tabs">
+                    <TabsList className="add-job__tab-list">
+                        <TabsTrigger value="link" className="add-job__tab">
+                            <Link2 aria-hidden className="add-job__tab-icon" />
+                            Link
+                        </TabsTrigger>
+                        <TabsTrigger value="paste" className="add-job__tab">
+                            <FileText aria-hidden className="add-job__tab-icon" />
+                            Paste
+                        </TabsTrigger>
+                        <TabsTrigger value="voice" className="add-job__tab">
+                            <Mic aria-hidden className="add-job__tab-icon" />
+                            Voice
+                        </TabsTrigger>
+                    </TabsList>
+
+                    <TabsContent value="link" className="add-job__panel">
+                        <div className="add-job__field">
+                            <Label htmlFor="job-url">Job Posting URL</Label>
+                            <div className="add-job__input-row">
+                                <Input
+                                    id="job-url"
+                                    placeholder="https://company.com/jobs/role-123"
+                                    value={jobUrl}
+                                    onChange={(event) => setJobUrl(event.target.value)}
+                                />
+                                <Button
+                                    onClick={handleLinkSubmit}
+                                    disabled={isLoading || !jobUrl.trim()}
+                                    aria-label="Parse job link"
+                                >
+                                    {isLoading ? <Loader2 aria-hidden className="add-job__spinner" /> : <ExternalLink aria-hidden />}
+                                </Button>
+                            </div>
+                            <p className="add-job__hint">Works with LinkedIn, Indeed, company career pages, and more.</p>
+                        </div>
+
+                        {isLoading && (
+                            <div className="add-job__status">
+                                <Loader2 aria-hidden className="add-job__spinner" />
+                                <div>
+                                    <p className="add-job__status-title">Parsing job posting…</p>
+                                    <p className="add-job__status-copy">Extracting company, role, and requirements</p>
+                                </div>
+                            </div>
+                        )}
+                    </TabsContent>
+
+                    <TabsContent value="paste" className="add-job__panel">
+                        <div className="add-job__field">
+                            <Label htmlFor="job-text">Job Description or Notes</Label>
+                            <Textarea
+                                id="job-text"
+                                placeholder="Paste job description, your notes, or any job-related text here…"
+                                value={jobText}
+                                onChange={(event) => setJobText(event.target.value)}
+                                rows={6}
+                            />
+                            <Button
+                                className="add-job__submit"
+                                onClick={handleTextSubmit}
+                                disabled={isLoading || !jobText.trim()}
+                            >
+                                {isLoading ? (
+                                    <>
+                                        <Loader2 aria-hidden className="add-job__spinner" /> Parsing Text…
+                                    </>
+                                ) : (
+                                    <>
+                                        <Building2 aria-hidden className="add-job__tab-icon" /> Parse &amp; Add Job
+                                    </>
+                                )}
+                            </Button>
+                        </div>
+                    </TabsContent>
+
+                    <TabsContent value="voice" className="add-job__panel">
+                        <div className="add-job__voice">
+                            <div className={isRecording ? "add-job__mic add-job__mic--active" : "add-job__mic"}>
+                                <Mic aria-hidden className="add-job__mic-icon" />
+                            </div>
+
+                            <div className="add-job__voice-copy">
+                                <h3>Voice Job Update</h3>
+                                <p>Say something like: “Applied to Google for PM role yesterday, interview Thursday”.</p>
+                            </div>
+
+                            <Button onClick={handleVoiceRecord} disabled={isRecording} className="add-job__voice-button">
+                                {isRecording ? (
+                                    <>
+                                        <Loader2 aria-hidden className="add-job__spinner" /> Listening…
+                                    </>
+                                ) : (
+                                    <>
+                                        <Mic aria-hidden className="add-job__tab-icon" /> Start Recording
+                                    </>
+                                )}
+                            </Button>
+                        </div>
+                    </TabsContent>
+                </Tabs>
+            </DialogContent>
+        </Dialog>
+    );
+};
+
+export default AddJobModal;

--- a/src/app/tracker/components/add-job-modal.css
+++ b/src/app/tracker/components/add-job-modal.css
@@ -1,0 +1,153 @@
+.add-job__content {
+    display: flex;
+    flex-direction: column;
+    gap: 1.2rem;
+}
+
+.add-job__title {
+    font-size: 1.4rem;
+    font-weight: 700;
+}
+
+.add-job__tabs {
+    width: 100%;
+}
+
+.add-job__tab-list {
+    background: rgba(148, 163, 184, 0.08);
+}
+
+.add-job__tab {
+    font-size: 0.85rem;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+}
+
+.add-job__tab-icon {
+    width: 1rem;
+    height: 1rem;
+}
+
+.add-job__panel {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+}
+
+.add-job__field {
+    display: flex;
+    flex-direction: column;
+    gap: 0.65rem;
+}
+
+.add-job__input-row {
+    display: flex;
+    gap: 0.6rem;
+}
+
+.add-job__input-row .ui-input {
+    flex: 1;
+}
+
+.add-job__hint {
+    font-size: 0.75rem;
+    color: rgba(226, 232, 240, 0.7);
+}
+
+.add-job__status {
+    display: flex;
+    align-items: center;
+    gap: 0.8rem;
+    padding: 0.75rem 1rem;
+    border-radius: 14px;
+    background: rgba(99, 102, 241, 0.12);
+    border: 1px solid rgba(99, 102, 241, 0.2);
+}
+
+.add-job__status-title {
+    font-weight: 600;
+}
+
+.add-job__status-copy {
+    font-size: 0.8rem;
+    color: rgba(226, 232, 240, 0.7);
+}
+
+.add-job__spinner {
+    width: 1rem;
+    height: 1rem;
+    animation: spin 1s linear infinite;
+}
+
+.add-job__submit {
+    width: 100%;
+}
+
+.add-job__voice {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 1.2rem;
+    text-align: center;
+}
+
+.add-job__mic {
+    width: 5rem;
+    height: 5rem;
+    border-radius: 999px;
+    background: rgba(148, 163, 184, 0.08);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    transition: transform 0.3s ease, box-shadow 0.3s ease;
+}
+
+.add-job__mic--active {
+    box-shadow: 0 0 0 12px rgba(79, 70, 229, 0.15);
+    transform: scale(1.05);
+}
+
+.add-job__mic-icon {
+    width: 2.5rem;
+    height: 2.5rem;
+    color: #60a5fa;
+}
+
+.add-job__voice-copy h3 {
+    font-size: 1.1rem;
+    font-weight: 600;
+}
+
+.add-job__voice-copy p {
+    font-size: 0.85rem;
+    color: rgba(226, 232, 240, 0.75);
+    max-width: 360px;
+    margin: 0 auto;
+}
+
+.add-job__voice-button {
+    min-width: 12rem;
+}
+
+@keyframes spin {
+    0% {
+        transform: rotate(0deg);
+    }
+    100% {
+        transform: rotate(360deg);
+    }
+}
+
+@media (max-width: 640px) {
+    .add-job__content {
+        padding: 1.2rem;
+    }
+
+    .add-job__input-row {
+        flex-direction: column;
+    }
+
+    .add-job__voice-button {
+        width: 100%;
+    }
+}

--- a/src/components/ui/accordion.tsx
+++ b/src/components/ui/accordion.tsx
@@ -1,0 +1,121 @@
+"use client";
+
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+export interface AccordionProps extends React.HTMLAttributes<HTMLDivElement> {
+    type?: "single" | "multiple";
+    collapsible?: boolean;
+    value?: string;
+    defaultValue?: string;
+    onValueChange?: (value: string) => void;
+}
+
+const AccordionContext = React.createContext<{
+    value: string | null;
+    setValue: (value: string) => void;
+    type: "single" | "multiple";
+    collapsible: boolean;
+} | null>(null);
+
+export const Accordion = ({
+    className,
+    children,
+    value,
+    defaultValue,
+    onValueChange,
+    type = "single",
+    collapsible = true,
+    ...props
+}: AccordionProps) => {
+    const [internalValue, setInternalValue] = React.useState(defaultValue ?? null);
+    const activeValue = value ?? internalValue;
+
+    const setValue = React.useCallback(
+        (next: string) => {
+            setInternalValue(next);
+            onValueChange?.(next);
+        },
+        [onValueChange]
+    );
+
+    return (
+        <AccordionContext.Provider
+            value={{
+                value: activeValue,
+                setValue,
+                type,
+                collapsible,
+            }}
+        >
+            <div className={cn("ui-accordion", className)} {...props}>
+                {children}
+            </div>
+        </AccordionContext.Provider>
+    );
+};
+
+const useAccordion = () => {
+    const context = React.useContext(AccordionContext);
+    if (!context) {
+        throw new Error("Accordion components must be used within <Accordion>");
+    }
+    return context;
+};
+
+export interface AccordionItemProps extends React.HTMLAttributes<HTMLDivElement> {
+    value: string;
+}
+
+export const AccordionItem = ({ value, className, children, ...props }: AccordionItemProps) => {
+    const { value: activeValue } = useAccordion();
+    const isOpen = activeValue === value;
+    return (
+        <div data-state={isOpen ? "open" : "closed"} className={cn("ui-accordion-item", className)} {...props}>
+            {children}
+        </div>
+    );
+};
+
+export interface AccordionTriggerProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+    value: string;
+}
+
+export const AccordionTrigger = React.forwardRef<HTMLButtonElement, AccordionTriggerProps>(
+    ({ value, className, ...props }, ref) => {
+        const { value: activeValue, setValue, collapsible } = useAccordion();
+        const isOpen = activeValue === value;
+        return (
+            <button
+                ref={ref}
+                type="button"
+                className={cn("ui-accordion-trigger", className)}
+                aria-expanded={isOpen}
+                data-state={isOpen ? "open" : "closed"}
+                onClick={(event) => {
+                    props.onClick?.(event);
+                    if (isOpen && collapsible) {
+                        setValue("");
+                    } else {
+                        setValue(value);
+                    }
+                }}
+                {...props}
+            />
+        );
+    }
+);
+
+AccordionTrigger.displayName = "AccordionTrigger";
+
+export interface AccordionContentProps extends React.HTMLAttributes<HTMLDivElement> {
+    value: string;
+}
+
+export const AccordionContent = ({ value, className, ...props }: AccordionContentProps) => {
+    const { value: activeValue } = useAccordion();
+    if (activeValue !== value) {
+        return null;
+    }
+    return <div className={cn("ui-accordion-content", className)} {...props} />;
+};

--- a/src/components/ui/alert-dialog.tsx
+++ b/src/components/ui/alert-dialog.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+import * as React from "react";
+import { Button } from "./button";
+import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from "./dialog";
+
+export const AlertDialog = Dialog;
+export const AlertDialogContent = DialogContent;
+export const AlertDialogDescription = DialogDescription;
+export const AlertDialogFooter = DialogFooter;
+export const AlertDialogHeader = DialogHeader;
+export const AlertDialogTitle = DialogTitle;
+
+export type AlertDialogTriggerProps = React.ButtonHTMLAttributes<HTMLButtonElement>;
+
+export const AlertDialogTrigger = React.forwardRef<HTMLButtonElement, AlertDialogTriggerProps>(({ className, ...props }, ref) => (
+    <Button ref={ref} className={className} {...props} />
+));
+
+AlertDialogTrigger.displayName = "AlertDialogTrigger";
+
+export const AlertDialogAction = React.forwardRef<HTMLButtonElement, React.ButtonHTMLAttributes<HTMLButtonElement>>(
+    ({ className, ...props }, ref) => <Button ref={ref} className={className} {...props} />
+);
+
+AlertDialogAction.displayName = "AlertDialogAction";
+
+export const AlertDialogCancel = React.forwardRef<HTMLButtonElement, React.ButtonHTMLAttributes<HTMLButtonElement>>(
+    ({ className, ...props }, ref) => (
+        <Button ref={ref} className={className} data-variant="secondary" {...props} />
+    )
+);
+
+AlertDialogCancel.displayName = "AlertDialogCancel";

--- a/src/components/ui/alert.tsx
+++ b/src/components/ui/alert.tsx
@@ -1,0 +1,18 @@
+"use client";
+
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+export const Alert = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(({ className, ...props }, ref) => (
+    <div ref={ref} role="alert" className={cn("ui-alert", className)} {...props} />
+));
+
+Alert.displayName = "Alert";
+
+export const AlertTitle = ({ className, ...props }: React.HTMLAttributes<HTMLHeadingElement>) => (
+    <h4 className={cn("ui-alert__title", className)} {...props} />
+);
+
+export const AlertDescription = ({ className, ...props }: React.HTMLAttributes<HTMLParagraphElement>) => (
+    <p className={cn("ui-alert__description", className)} {...props} />
+);

--- a/src/components/ui/aspect-ratio.tsx
+++ b/src/components/ui/aspect-ratio.tsx
@@ -1,0 +1,24 @@
+"use client";
+
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+export interface AspectRatioProps extends React.HTMLAttributes<HTMLDivElement> {
+    ratio?: number;
+}
+
+export const AspectRatio = ({ ratio = 16 / 9, className, style, children, ...props }: AspectRatioProps) => {
+    return (
+        <div
+            className={cn("ui-aspect-ratio", className)}
+            style={{
+                position: "relative",
+                paddingBottom: `${100 / ratio}%`,
+                ...style,
+            }}
+            {...props}
+        >
+            <div style={{ position: "absolute", inset: 0 }}>{children}</div>
+        </div>
+    );
+};

--- a/src/components/ui/avatar.tsx
+++ b/src/components/ui/avatar.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+/* eslint-disable @next/next/no-img-element */
+
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+export const Avatar = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(({ className, ...props }, ref) => (
+    <div ref={ref} className={cn("ui-avatar", className)} {...props} />
+));
+
+Avatar.displayName = "Avatar";
+
+export type AvatarImageProps = React.ImgHTMLAttributes<HTMLImageElement>;
+
+export const AvatarImage = React.forwardRef<HTMLImageElement, AvatarImageProps>(({ className, alt = "", ...props }, ref) => (
+    <img ref={ref} className={cn("ui-avatar__image", className)} alt={alt} {...props} />
+));
+
+AvatarImage.displayName = "AvatarImage";
+
+export const AvatarFallback = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+    ({ className, ...props }, ref) => (
+        <div ref={ref} className={cn("ui-avatar__fallback", className)} {...props} />
+    )
+);
+
+AvatarFallback.displayName = "AvatarFallback";

--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -1,0 +1,12 @@
+"use client";
+
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+export interface BadgeProps extends React.HTMLAttributes<HTMLSpanElement> {
+    variant?: "default" | "secondary" | "outline";
+}
+
+export const Badge = ({ className, variant = "default", ...props }: BadgeProps) => (
+    <span className={cn("ui-badge", `ui-badge--${variant}`, className)} {...props} />
+);

--- a/src/components/ui/breadcrumb.tsx
+++ b/src/components/ui/breadcrumb.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+export const Breadcrumb = ({ className, ...props }: React.HTMLAttributes<HTMLElement>) => (
+    <nav aria-label="Breadcrumb" className={cn("ui-breadcrumb", className)} {...props} />
+);
+
+export const BreadcrumbList = ({ className, ...props }: React.OlHTMLAttributes<HTMLOListElement>) => (
+    <ol className={cn("ui-breadcrumb__list", className)} {...props} />
+);
+
+export const BreadcrumbItem = ({ className, ...props }: React.LiHTMLAttributes<HTMLLIElement>) => (
+    <li className={cn("ui-breadcrumb__item", className)} {...props} />
+);
+
+export const BreadcrumbLink = React.forwardRef<HTMLAnchorElement, React.AnchorHTMLAttributes<HTMLAnchorElement>>(
+    ({ className, ...props }, ref) => <a ref={ref} className={cn("ui-breadcrumb__link", className)} {...props} />
+);
+
+BreadcrumbLink.displayName = "BreadcrumbLink";
+
+export const BreadcrumbSeparator = ({ className, children = "/", ...props }: React.HTMLAttributes<HTMLSpanElement>) => (
+    <span className={cn("ui-breadcrumb__separator", className)} role="presentation" {...props}>
+        {children}
+    </span>
+);
+
+export const BreadcrumbEllipsis = (props: React.HTMLAttributes<HTMLSpanElement>) => (
+    <BreadcrumbSeparator {...props}>…</BreadcrumbSeparator>
+);
+
+export const BreadcrumbPage = ({ className, ...props }: React.HTMLAttributes<HTMLSpanElement>) => (
+    <span className={cn("ui-breadcrumb__page", className)} aria-current="page" {...props} />
+);

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+type ButtonVariant = "default" | "secondary" | "ghost" | "link" | "danger";
+type ButtonSize = "default" | "sm" | "lg" | "icon";
+
+export interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+    variant?: ButtonVariant;
+    size?: ButtonSize;
+}
+
+export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(({ className, variant = "default", size = "default", type = "button", ...props }, ref) => {
+    return (
+        <button
+            ref={ref}
+            type={type}
+            data-variant={variant}
+            data-size={size}
+            className={cn("ui-button", className)}
+            {...props}
+        />
+    );
+});
+
+Button.displayName = "Button";

--- a/src/components/ui/calendar.tsx
+++ b/src/components/ui/calendar.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+import * as React from "react";
+
+export interface CalendarProps extends React.InputHTMLAttributes<HTMLInputElement> {
+    selected?: Date;
+    onSelect?: (date: Date | undefined) => void;
+}
+
+export const Calendar = React.forwardRef<HTMLInputElement, CalendarProps>(({ selected, onSelect, ...props }, ref) => {
+    const formatted = selected ? selected.toISOString().split("T")[0] : "";
+    return (
+        <input
+            ref={ref}
+            type="date"
+            value={formatted}
+            onChange={(event) => {
+                const value = event.target.value;
+                if (!value) {
+                    onSelect?.(undefined);
+                } else {
+                    onSelect?.(new Date(value));
+                }
+            }}
+            {...props}
+        />
+    );
+});
+
+Calendar.displayName = "Calendar";

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+export const Card = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(({ className, ...props }, ref) => (
+    <div ref={ref} className={cn("ui-card", className)} {...props} />
+));
+
+Card.displayName = "Card";
+
+export const CardHeader = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+    <div className={cn("ui-card__header", className)} {...props} />
+);
+
+export const CardContent = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+    <div className={cn("ui-card__content", className)} {...props} />
+);
+
+export const CardFooter = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+    <div className={cn("ui-card__footer", className)} {...props} />
+);
+
+export const CardTitle = ({ className, ...props }: React.HTMLAttributes<HTMLHeadingElement>) => (
+    <h3 className={cn("ui-card__title", className)} {...props} />
+);
+
+export const CardDescription = ({ className, ...props }: React.HTMLAttributes<HTMLParagraphElement>) => (
+    <p className={cn("ui-card__description", className)} {...props} />
+);

--- a/src/components/ui/carousel.tsx
+++ b/src/components/ui/carousel.tsx
@@ -1,0 +1,89 @@
+"use client";
+
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+interface CarouselContextValue {
+    index: number;
+    setIndex: (index: number) => void;
+    count: number;
+    registerItem: () => number;
+}
+
+const CarouselContext = React.createContext<CarouselContextValue | null>(null);
+
+export type CarouselProps = React.HTMLAttributes<HTMLDivElement>;
+
+export const Carousel = ({ className, children, ...props }: CarouselProps) => {
+    const [index, setIndex] = React.useState(0);
+    const [count, setCount] = React.useState(0);
+
+    const registerItem = React.useCallback(() => {
+        setCount((prev) => prev + 1);
+        return count;
+    }, [count]);
+
+    const value = React.useMemo(() => ({ index, setIndex, count, registerItem }), [index, count, registerItem]);
+
+    return (
+        <CarouselContext.Provider value={value}>
+            <div className={cn("ui-carousel", className)} {...props}>
+                {children}
+            </div>
+        </CarouselContext.Provider>
+    );
+};
+
+const useCarousel = () => {
+    const context = React.useContext(CarouselContext);
+    if (!context) {
+        throw new Error("Carousel components must be used within <Carousel>");
+    }
+    return context;
+};
+
+export const CarouselContent = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+    <div className={cn("ui-carousel__content", className)} {...props} />
+);
+
+export const CarouselItem = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => {
+    const { registerItem } = useCarousel();
+    React.useEffect(() => {
+        registerItem();
+    }, [registerItem]);
+    return <div className={cn("ui-carousel__item", className)} {...props} />;
+};
+
+export const CarouselNext = ({ className, ...props }: React.ButtonHTMLAttributes<HTMLButtonElement>) => {
+    const { index, setIndex, count } = useCarousel();
+    return (
+        <button
+            type="button"
+            className={cn("ui-carousel__control", className)}
+            onClick={(event) => {
+                props.onClick?.(event);
+                setIndex((index + 1) % Math.max(count, 1));
+            }}
+            {...props}
+        >
+            ›
+        </button>
+    );
+};
+
+export const CarouselPrevious = ({ className, ...props }: React.ButtonHTMLAttributes<HTMLButtonElement>) => {
+    const { index, setIndex, count } = useCarousel();
+    return (
+        <button
+            type="button"
+            className={cn("ui-carousel__control", className)}
+            onClick={(event) => {
+                props.onClick?.(event);
+                setIndex((index - 1 + Math.max(count, 1)) % Math.max(count, 1));
+            }}
+            {...props}
+        >
+            ‹
+        </button>
+    );
+};

--- a/src/components/ui/chart.tsx
+++ b/src/components/ui/chart.tsx
@@ -1,0 +1,14 @@
+"use client";
+
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+export interface ChartProps extends React.HTMLAttributes<HTMLDivElement> {
+    data?: unknown;
+}
+
+export const Chart = ({ className, children, ...props }: ChartProps) => (
+    <div className={cn("ui-chart", className)} {...props}>
+        {children}
+    </div>
+);

--- a/src/components/ui/checkbox.tsx
+++ b/src/components/ui/checkbox.tsx
@@ -1,0 +1,12 @@
+"use client";
+
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+export type CheckboxProps = React.InputHTMLAttributes<HTMLInputElement>;
+
+export const Checkbox = React.forwardRef<HTMLInputElement, CheckboxProps>(({ className, ...props }, ref) => (
+    <input ref={ref} type="checkbox" className={cn("ui-checkbox", className)} {...props} />
+));
+
+Checkbox.displayName = "Checkbox";

--- a/src/components/ui/collapsible.tsx
+++ b/src/components/ui/collapsible.tsx
@@ -1,0 +1,75 @@
+"use client";
+
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+interface CollapsibleContextValue {
+    open: boolean;
+    setOpen: (open: boolean) => void;
+}
+
+const CollapsibleContext = React.createContext<CollapsibleContextValue | null>(null);
+
+export interface CollapsibleProps extends React.HTMLAttributes<HTMLDivElement> {
+    open?: boolean;
+    defaultOpen?: boolean;
+    onOpenChange?: (open: boolean) => void;
+}
+
+export const Collapsible = ({ open, defaultOpen = false, onOpenChange, className, children, ...props }: CollapsibleProps) => {
+    const [internal, setInternal] = React.useState(defaultOpen);
+    const isOpen = open ?? internal;
+
+    const setOpen = React.useCallback(
+        (value: boolean) => {
+            setInternal(value);
+            onOpenChange?.(value);
+        },
+        [onOpenChange]
+    );
+
+    return (
+        <CollapsibleContext.Provider value={{ open: isOpen, setOpen }}>
+            <div className={cn("ui-collapsible", className)} {...props}>
+                {children}
+            </div>
+        </CollapsibleContext.Provider>
+    );
+};
+
+const useCollapsible = () => {
+    const context = React.useContext(CollapsibleContext);
+    if (!context) {
+        throw new Error("Collapsible components must be used within <Collapsible>");
+    }
+    return context;
+};
+
+export const CollapsibleTrigger = React.forwardRef<HTMLButtonElement, React.ButtonHTMLAttributes<HTMLButtonElement>>(
+    ({ className, ...props }, ref) => {
+        const { open, setOpen } = useCollapsible();
+        return (
+            <button
+                ref={ref}
+                type="button"
+                className={cn("ui-collapsible__trigger", className)}
+                aria-expanded={open}
+                onClick={(event) => {
+                    props.onClick?.(event);
+                    setOpen(!open);
+                }}
+                {...props}
+            />
+        );
+    }
+);
+
+CollapsibleTrigger.displayName = "CollapsibleTrigger";
+
+export const CollapsibleContent = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => {
+    const { open } = useCollapsible();
+    if (!open) {
+        return null;
+    }
+    return <div className={cn("ui-collapsible__content", className)} {...props} />;
+};

--- a/src/components/ui/command.tsx
+++ b/src/components/ui/command.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+export const Command = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+    <div className={cn("ui-command", className)} role="listbox" {...props} />
+);
+
+export const CommandInput = React.forwardRef<HTMLInputElement, React.InputHTMLAttributes<HTMLInputElement>>(
+    ({ className, ...props }, ref) => <input ref={ref} className={cn("ui-command__input", className)} {...props} />
+);
+
+CommandInput.displayName = "CommandInput";
+
+export const CommandList = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+    <div className={cn("ui-command__list", className)} {...props} />
+);
+
+export const CommandGroup = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+    <div className={cn("ui-command__group", className)} {...props} />
+);
+
+export const CommandItem = ({ className, "aria-selected": ariaSelected, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+    <div className={cn("ui-command__item", className)} role="option" aria-selected={ariaSelected ?? false} {...props} />
+);
+
+export const CommandSeparator = ({ className, ...props }: React.HTMLAttributes<HTMLHRElement>) => (
+    <hr className={cn("ui-command__separator", className)} {...props} />
+);
+
+export const CommandEmpty = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+    <div className={cn("ui-command__empty", className)} {...props} />
+);

--- a/src/components/ui/context-menu.tsx
+++ b/src/components/ui/context-menu.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+export const ContextMenu = ({ children }: { children: React.ReactNode }) => <>{children}</>;
+
+export const ContextMenuTrigger = ({ children }: { children: React.ReactNode }) => <>{children}</>;
+
+export const ContextMenuContent = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+    <div className={cn("ui-context-menu", className)} role="menu" {...props} />
+);
+
+export const ContextMenuItem = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+    <div className={cn("ui-context-menu__item", className)} role="menuitem" {...props} />
+);
+
+export const ContextMenuSeparator = ({ className, ...props }: React.HTMLAttributes<HTMLHRElement>) => (
+    <hr className={cn("ui-context-menu__separator", className)} {...props} />
+);
+
+export const ContextMenuLabel = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+    <div className={cn("ui-context-menu__label", className)} {...props} />
+);
+
+export const ContextMenuCheckboxItem = ({ className, ...props }: React.InputHTMLAttributes<HTMLInputElement>) => (
+    <label className={cn("ui-context-menu__checkbox", className)}>
+        <input type="checkbox" {...props} />
+        <span>{props.children}</span>
+    </label>
+);
+
+export const ContextMenuRadioGroup = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+    <div className={cn("ui-context-menu__radio-group", className)} {...props} />
+);
+
+export const ContextMenuRadioItem = ({ className, ...props }: React.InputHTMLAttributes<HTMLInputElement>) => (
+    <label className={cn("ui-context-menu__radio", className)}>
+        <input type="radio" {...props} />
+        <span>{props.children}</span>
+    </label>
+);

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -1,0 +1,93 @@
+"use client";
+
+import * as React from "react";
+import { createPortal } from "react-dom";
+import { cn } from "@/lib/utils";
+
+interface DialogContextValue {
+    open: boolean;
+    onOpenChange?: (open: boolean) => void;
+}
+
+const DialogContext = React.createContext<DialogContextValue | null>(null);
+
+export interface DialogProps {
+    open: boolean;
+    onOpenChange?: (open: boolean) => void;
+    children: React.ReactNode;
+}
+
+export const Dialog = ({ open, onOpenChange, children }: DialogProps) => {
+    const value = React.useMemo(() => ({ open, onOpenChange }), [open, onOpenChange]);
+    return <DialogContext.Provider value={value}>{children}</DialogContext.Provider>;
+};
+
+const useDialog = () => {
+    const context = React.useContext(DialogContext);
+    if (!context) {
+        throw new Error("Dialog components must be used within a Dialog");
+    }
+    return context;
+};
+
+export interface DialogContentProps extends React.HTMLAttributes<HTMLDivElement> {
+    overlayClassName?: string;
+}
+
+export const DialogContent = ({ className, overlayClassName, children, ...props }: DialogContentProps) => {
+    const { open, onOpenChange } = useDialog();
+    const content = !open
+        ? null
+        : createPortal(
+              <div className={cn("ui-dialog-overlay", overlayClassName)} role="presentation" onClick={() => onOpenChange?.(false)}>
+                  <div
+                      className={cn("ui-dialog-content", className)}
+                      role="dialog"
+                      aria-modal="true"
+                      onClick={(event) => event.stopPropagation()}
+                      {...props}
+                  >
+                      {children}
+                  </div>
+              </div>,
+              document.body
+          );
+
+    return content;
+};
+
+export const DialogHeader = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+    <div className={cn("ui-dialog-header", className)} {...props} />
+);
+
+export const DialogTitle = ({ className, ...props }: React.HTMLAttributes<HTMLHeadingElement>) => (
+    <h2 className={cn("ui-dialog-title", className)} {...props} />
+);
+
+export const DialogDescription = ({ className, ...props }: React.HTMLAttributes<HTMLParagraphElement>) => (
+    <p className={cn("ui-dialog-description", className)} {...props} />
+);
+
+export const DialogFooter = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+    <div className={cn("ui-dialog-footer", className)} {...props} />
+);
+
+export const DialogClose = React.forwardRef<HTMLButtonElement, React.ButtonHTMLAttributes<HTMLButtonElement>>(
+    ({ className, ...props }, ref) => {
+        const { onOpenChange } = useDialog();
+        return (
+            <button
+                ref={ref}
+                type="button"
+                className={cn("ui-dialog-close", className)}
+                onClick={(event) => {
+                    props.onClick?.(event);
+                    onOpenChange?.(false);
+                }}
+                {...props}
+            />
+        );
+    }
+);
+
+DialogClose.displayName = "DialogClose";

--- a/src/components/ui/drawer.tsx
+++ b/src/components/ui/drawer.tsx
@@ -1,0 +1,88 @@
+"use client";
+
+import * as React from "react";
+import { createPortal } from "react-dom";
+import { cn } from "@/lib/utils";
+
+interface DrawerContextValue {
+    open: boolean;
+    onOpenChange?: (open: boolean) => void;
+}
+
+const DrawerContext = React.createContext<DrawerContextValue | null>(null);
+
+export interface DrawerProps {
+    open: boolean;
+    onOpenChange?: (open: boolean) => void;
+    children: React.ReactNode;
+}
+
+export const Drawer = ({ open, onOpenChange, children }: DrawerProps) => {
+    const value = React.useMemo(() => ({ open, onOpenChange }), [open, onOpenChange]);
+    return <DrawerContext.Provider value={value}>{children}</DrawerContext.Provider>;
+};
+
+const useDrawer = () => {
+    const context = React.useContext(DrawerContext);
+    if (!context) {
+        throw new Error("Drawer components must be used within <Drawer>");
+    }
+    return context;
+};
+
+export const DrawerTrigger = ({ children, ...props }: React.ButtonHTMLAttributes<HTMLButtonElement>) => (
+    <button type="button" {...props}>
+        {children}
+    </button>
+);
+
+export const DrawerContent = ({ className, children, ...props }: React.HTMLAttributes<HTMLDivElement>) => {
+    const { open, onOpenChange } = useDrawer();
+    if (!open) {
+        return null;
+    }
+    return createPortal(
+        <div className="ui-drawer-overlay" role="presentation" onClick={() => onOpenChange?.(false)}>
+            <aside className={cn("ui-drawer", className)} onClick={(event) => event.stopPropagation()} {...props}>
+                {children}
+            </aside>
+        </div>,
+        document.body
+    );
+};
+
+export const DrawerHeader = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+    <div className={cn("ui-drawer__header", className)} {...props} />
+);
+
+export const DrawerFooter = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+    <div className={cn("ui-drawer__footer", className)} {...props} />
+);
+
+export const DrawerTitle = ({ className, ...props }: React.HTMLAttributes<HTMLHeadingElement>) => (
+    <h2 className={cn("ui-drawer__title", className)} {...props} />
+);
+
+export const DrawerDescription = ({ className, ...props }: React.HTMLAttributes<HTMLParagraphElement>) => (
+    <p className={cn("ui-drawer__description", className)} {...props} />
+);
+
+export const DrawerClose = React.forwardRef<HTMLButtonElement, React.ButtonHTMLAttributes<HTMLButtonElement>>(
+    ({ className, ...props }, ref) => {
+        const { onOpenChange } = useDrawer();
+        return (
+            <button
+                ref={ref}
+                type="button"
+                className={cn("ui-drawer__close", className)}
+                onClick={(event) => {
+                    props.onClick?.(event);
+                    onOpenChange?.(false);
+                }}
+                {...props}
+            />
+        );
+    }
+);
+
+DrawerClose.displayName = "DrawerClose";

--- a/src/components/ui/dropdown-menu.tsx
+++ b/src/components/ui/dropdown-menu.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+export const DropdownMenu = ({ children }: { children: React.ReactNode }) => <>{children}</>;
+
+export const DropdownMenuTrigger = React.forwardRef<HTMLButtonElement, React.ButtonHTMLAttributes<HTMLButtonElement>>(
+    ({ className, ...props }, ref) => <button ref={ref} type="button" className={cn("ui-dropdown__trigger", className)} {...props} />
+);
+
+DropdownMenuTrigger.displayName = "DropdownMenuTrigger";
+
+export const DropdownMenuContent = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+    <div className={cn("ui-dropdown", className)} role="menu" {...props} />
+);
+
+export const DropdownMenuLabel = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+    <div className={cn("ui-dropdown__label", className)} {...props} />
+);
+
+export const DropdownMenuItem = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+    <div className={cn("ui-dropdown__item", className)} role="menuitem" tabIndex={0} {...props} />
+);
+
+export const DropdownMenuSeparator = ({ className, ...props }: React.HTMLAttributes<HTMLHRElement>) => (
+    <hr className={cn("ui-dropdown__separator", className)} {...props} />
+);
+
+export const DropdownMenuCheckboxItem = ({ className, ...props }: React.InputHTMLAttributes<HTMLInputElement>) => (
+    <label className={cn("ui-dropdown__checkbox", className)}>
+        <input type="checkbox" {...props} />
+        <span>{props.children}</span>
+    </label>
+);
+
+export const DropdownMenuRadioGroup = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+    <div className={cn("ui-dropdown__radio-group", className)} {...props} />
+);
+
+export const DropdownMenuRadioItem = ({ className, ...props }: React.InputHTMLAttributes<HTMLInputElement>) => (
+    <label className={cn("ui-dropdown__radio", className)}>
+        <input type="radio" {...props} />
+        <span>{props.children}</span>
+    </label>
+);

--- a/src/components/ui/form.tsx
+++ b/src/components/ui/form.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+export const Form = ({ className, ...props }: React.FormHTMLAttributes<HTMLFormElement>) => (
+    <form className={cn("ui-form", className)} {...props} />
+);
+
+export const FormField = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+    <div className={cn("ui-form__field", className)} {...props} />
+);
+
+export const FormItem = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+    <div className={cn("ui-form__item", className)} {...props} />
+);
+
+export const FormLabel = ({ className, ...props }: React.LabelHTMLAttributes<HTMLLabelElement>) => (
+    <label className={cn("ui-form__label", className)} {...props} />
+);
+
+export const FormControl = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+    <div className={cn("ui-form__control", className)} {...props} />
+);
+
+export const FormDescription = ({ className, ...props }: React.HTMLAttributes<HTMLParagraphElement>) => (
+    <p className={cn("ui-form__description", className)} {...props} />
+);
+
+export const FormMessage = ({ className, ...props }: React.HTMLAttributes<HTMLParagraphElement>) => (
+    <p className={cn("ui-form__message", className)} {...props} />
+);

--- a/src/components/ui/hover-card.tsx
+++ b/src/components/ui/hover-card.tsx
@@ -1,0 +1,12 @@
+"use client";
+
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+export const HoverCard = ({ children }: { children: React.ReactNode }) => <>{children}</>;
+
+export const HoverCardTrigger = ({ children }: { children: React.ReactNode }) => <>{children}</>;
+
+export const HoverCardContent = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+    <div className={cn("ui-hover-card", className)} {...props} />
+);

--- a/src/components/ui/input-otp.tsx
+++ b/src/components/ui/input-otp.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+export interface InputOTPProps extends React.HTMLAttributes<HTMLDivElement> {
+    length?: number;
+    value?: string;
+    onChange?: (value: string) => void;
+}
+
+export const InputOTP = ({ length = 6, value = "", onChange, className, ...props }: InputOTPProps) => {
+    const characters = value.split("");
+    return (
+        <div className={cn("ui-input-otp", className)} {...props}>
+            {Array.from({ length }).map((_, index) => (
+                <input
+                    key={index}
+                    type="text"
+                    inputMode="numeric"
+                    maxLength={1}
+                    className="ui-input-otp__slot"
+                    value={characters[index] ?? ""}
+                    onChange={(event) => {
+                        const next = characters.slice();
+                        next[index] = event.target.value.slice(-1);
+                        onChange?.(next.join(""));
+                    }}
+                />
+            ))}
+        </div>
+    );
+};
+
+export const InputOTPSlot = ({ className, ...props }: React.InputHTMLAttributes<HTMLInputElement>) => (
+    <input className={cn("ui-input-otp__slot", className)} maxLength={1} {...props} />
+);

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -1,0 +1,12 @@
+"use client";
+
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+export type InputProps = React.InputHTMLAttributes<HTMLInputElement>;
+
+export const Input = React.forwardRef<HTMLInputElement, InputProps>(({ className, type = "text", ...props }, ref) => {
+    return <input ref={ref} type={type} className={cn("ui-input", className)} {...props} />;
+});
+
+Input.displayName = "Input";

--- a/src/components/ui/label.tsx
+++ b/src/components/ui/label.tsx
@@ -1,0 +1,12 @@
+"use client";
+
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+export type LabelProps = React.LabelHTMLAttributes<HTMLLabelElement>;
+
+export const Label = React.forwardRef<HTMLLabelElement, LabelProps>(({ className, ...props }, ref) => (
+    <label ref={ref} className={cn("ui-label", className)} {...props} />
+));
+
+Label.displayName = "Label";

--- a/src/components/ui/menubar.tsx
+++ b/src/components/ui/menubar.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+export const Menubar = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+    <div className={cn("ui-menubar", className)} role="menubar" {...props} />
+);
+
+export const MenubarMenu = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+    <div className={cn("ui-menubar__menu", className)} {...props} />
+);
+
+export const MenubarTrigger = React.forwardRef<HTMLButtonElement, React.ButtonHTMLAttributes<HTMLButtonElement>>(
+    ({ className, ...props }, ref) => <button ref={ref} type="button" className={cn("ui-menubar__trigger", className)} {...props} />
+);
+
+MenubarTrigger.displayName = "MenubarTrigger";
+
+export const MenubarContent = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+    <div className={cn("ui-menubar__content", className)} role="menu" {...props} />
+);
+
+export const MenubarItem = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+    <div className={cn("ui-menubar__item", className)} role="menuitem" {...props} />
+);
+
+export const MenubarSeparator = ({ className, ...props }: React.HTMLAttributes<HTMLHRElement>) => (
+    <hr className={cn("ui-menubar__separator", className)} {...props} />
+);
+
+export const MenubarLabel = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+    <div className={cn("ui-menubar__label", className)} {...props} />
+);

--- a/src/components/ui/navigation-menu.tsx
+++ b/src/components/ui/navigation-menu.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+export const NavigationMenu = ({ className, ...props }: React.HTMLAttributes<HTMLElement>) => (
+    <nav className={cn("ui-navigation-menu", className)} {...props} />
+);
+
+export const NavigationMenuList = ({ className, ...props }: React.HTMLAttributes<HTMLUListElement>) => (
+    <ul className={cn("ui-navigation-menu__list", className)} {...props} />
+);
+
+export const NavigationMenuItem = ({ className, ...props }: React.HTMLAttributes<HTMLLIElement>) => (
+    <li className={cn("ui-navigation-menu__item", className)} {...props} />
+);
+
+export const NavigationMenuLink = React.forwardRef<HTMLAnchorElement, React.AnchorHTMLAttributes<HTMLAnchorElement>>(
+    ({ className, ...props }, ref) => <a ref={ref} className={cn("ui-navigation-menu__link", className)} {...props} />
+);
+
+NavigationMenuLink.displayName = "NavigationMenuLink";
+
+export const NavigationMenuTrigger = React.forwardRef<HTMLButtonElement, React.ButtonHTMLAttributes<HTMLButtonElement>>(
+    ({ className, ...props }, ref) => <button ref={ref} type="button" className={cn("ui-navigation-menu__trigger", className)} {...props} />
+);
+
+NavigationMenuTrigger.displayName = "NavigationMenuTrigger";
+
+export const NavigationMenuContent = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+    <div className={cn("ui-navigation-menu__content", className)} {...props} />
+);

--- a/src/components/ui/pagination.tsx
+++ b/src/components/ui/pagination.tsx
@@ -1,0 +1,47 @@
+"use client";
+
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+export interface PaginationProps extends React.HTMLAttributes<HTMLElement> {
+    page?: number;
+    pageCount?: number;
+    onPageChange?: (page: number) => void;
+}
+
+export const Pagination = ({ page = 1, pageCount = 1, onPageChange, className, ...props }: PaginationProps) => {
+    const pages = Array.from({ length: pageCount }, (_, index) => index + 1);
+    return (
+        <nav className={cn("ui-pagination", className)} aria-label="Pagination" {...props}>
+            <button
+                type="button"
+                className="ui-pagination__control"
+                onClick={() => onPageChange?.(Math.max(1, page - 1))}
+                disabled={page <= 1}
+            >
+                Previous
+            </button>
+            <ul className="ui-pagination__list">
+                {pages.map((value) => (
+                    <li key={value}>
+                        <button
+                            type="button"
+                            className={cn("ui-pagination__item", value === page && "is-active")}
+                            onClick={() => onPageChange?.(value)}
+                        >
+                            {value}
+                        </button>
+                    </li>
+                ))}
+            </ul>
+            <button
+                type="button"
+                className="ui-pagination__control"
+                onClick={() => onPageChange?.(Math.min(pageCount, page + 1))}
+                disabled={page >= pageCount}
+            >
+                Next
+            </button>
+        </nav>
+    );
+};

--- a/src/components/ui/popover.tsx
+++ b/src/components/ui/popover.tsx
@@ -1,0 +1,67 @@
+"use client";
+
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+interface PopoverContextValue {
+    open: boolean;
+    setOpen: (open: boolean) => void;
+}
+
+const PopoverContext = React.createContext<PopoverContextValue | null>(null);
+
+export interface PopoverProps {
+    open?: boolean;
+    defaultOpen?: boolean;
+    onOpenChange?: (open: boolean) => void;
+    children: React.ReactNode;
+}
+
+export const Popover = ({ open, defaultOpen = false, onOpenChange, children }: PopoverProps) => {
+    const [internal, setInternal] = React.useState(defaultOpen);
+    const isOpen = open ?? internal;
+
+    const setOpen = React.useCallback(
+        (next: boolean) => {
+            setInternal(next);
+            onOpenChange?.(next);
+        },
+        [onOpenChange]
+    );
+
+    return <PopoverContext.Provider value={{ open: isOpen, setOpen }}>{children}</PopoverContext.Provider>;
+};
+
+const usePopover = () => {
+    const context = React.useContext(PopoverContext);
+    if (!context) {
+        throw new Error("Popover components must be used within <Popover>");
+    }
+    return context;
+};
+
+export const PopoverTrigger = ({ className, ...props }: React.ButtonHTMLAttributes<HTMLButtonElement>) => {
+    const { open, setOpen } = usePopover();
+    return (
+        <button
+            type="button"
+            className={cn("ui-popover__trigger", className)}
+            aria-expanded={open}
+            onClick={(event) => {
+                props.onClick?.(event);
+                setOpen(!open);
+            }}
+            {...props}
+        />
+    );
+};
+
+export const PopoverContent = ({ className, children, ...props }: React.HTMLAttributes<HTMLDivElement>) => {
+    const { open } = usePopover();
+    if (!open) return null;
+    return (
+        <div className={cn("ui-popover", className)} role="dialog" {...props}>
+            {children}
+        </div>
+    );
+};

--- a/src/components/ui/progress.tsx
+++ b/src/components/ui/progress.tsx
@@ -1,0 +1,18 @@
+"use client";
+
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+export interface ProgressProps extends React.HTMLAttributes<HTMLDivElement> {
+    value?: number;
+    max?: number;
+}
+
+export const Progress = ({ value = 0, max = 100, className, ...props }: ProgressProps) => {
+    const percent = Math.min(Math.max(value / max, 0), 1) * 100;
+    return (
+        <div className={cn("ui-progress", className)} role="progressbar" aria-valuenow={value} aria-valuemin={0} aria-valuemax={max} {...props}>
+            <div className="ui-progress__indicator" style={{ width: `${percent}%` }} />
+        </div>
+    );
+};

--- a/src/components/ui/radio-group.tsx
+++ b/src/components/ui/radio-group.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+interface RadioGroupContextValue {
+    value: string | undefined;
+    setValue: (value: string) => void;
+}
+
+const RadioGroupContext = React.createContext<RadioGroupContextValue | null>(null);
+
+export interface RadioGroupProps extends React.HTMLAttributes<HTMLDivElement> {
+    value?: string;
+    defaultValue?: string;
+    onValueChange?: (value: string) => void;
+}
+
+export const RadioGroup = ({ value, defaultValue, onValueChange, className, children, ...props }: RadioGroupProps) => {
+    const [internal, setInternal] = React.useState(defaultValue);
+    const current = value ?? internal;
+
+    const setValue = React.useCallback(
+        (next: string) => {
+            setInternal(next);
+            onValueChange?.(next);
+        },
+        [onValueChange]
+    );
+
+    return (
+        <RadioGroupContext.Provider value={{ value: current, setValue }}>
+            <div className={cn("ui-radio-group", className)} role="radiogroup" {...props}>
+                {children}
+            </div>
+        </RadioGroupContext.Provider>
+    );
+};
+
+const useRadioGroup = () => {
+    const context = React.useContext(RadioGroupContext);
+    if (!context) {
+        throw new Error("RadioGroupItem must be used inside <RadioGroup>");
+    }
+    return context;
+};
+
+export interface RadioGroupItemProps extends React.InputHTMLAttributes<HTMLInputElement> {
+    value: string;
+}
+
+export const RadioGroupItem = React.forwardRef<HTMLInputElement, RadioGroupItemProps>(({ value, className, ...props }, ref) => {
+    const { value: selected, setValue } = useRadioGroup();
+    return (
+        <label className={cn("ui-radio-group__item", className)}>
+            <input
+                ref={ref}
+                type="radio"
+                checked={selected === value}
+                onChange={() => setValue(value)}
+                {...props}
+            />
+            <span>{props.children}</span>
+        </label>
+    );
+});
+
+RadioGroupItem.displayName = "RadioGroupItem";

--- a/src/components/ui/resizable.tsx
+++ b/src/components/ui/resizable.tsx
@@ -1,0 +1,16 @@
+"use client";
+
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+export const ResizablePanelGroup = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+    <div className={cn("ui-resizable-group", className)} {...props} />
+);
+
+export const ResizablePanel = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+    <div className={cn("ui-resizable-panel", className)} {...props} />
+);
+
+export const ResizableHandle = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+    <div className={cn("ui-resizable-handle", className)} {...props} />
+);

--- a/src/components/ui/scroll-area.tsx
+++ b/src/components/ui/scroll-area.tsx
@@ -1,0 +1,12 @@
+"use client";
+
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+export const ScrollArea = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+    <div className={cn("ui-scroll-area", className)} {...props} />
+);
+
+export const ScrollBar = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+    <div className={cn("ui-scroll-bar", className)} {...props} />
+);

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+export type SelectProps = React.SelectHTMLAttributes<HTMLSelectElement>;
+
+export const Select = React.forwardRef<HTMLSelectElement, SelectProps>(({ className, children, ...props }, ref) => (
+    <select ref={ref} className={cn("ui-select", className)} {...props}>
+        {children}
+    </select>
+));
+
+Select.displayName = "Select";
+
+export const SelectTrigger = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+    ({ className, ...props }, ref) => <div ref={ref} className={cn("ui-select__trigger", className)} {...props} />
+);
+
+SelectTrigger.displayName = "SelectTrigger";
+
+export const SelectContent = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+    <div className={cn("ui-select__content", className)} {...props} />
+);
+
+export const SelectItem = ({ className, ...props }: React.OptionHTMLAttributes<HTMLOptionElement>) => (
+    <option className={cn("ui-select__item", className)} {...props} />
+);
+
+export const SelectValue = ({ placeholder, value }: { placeholder?: string; value?: string }) => (
+    <span className="ui-select__value">{value ?? placeholder ?? ""}</span>
+);

--- a/src/components/ui/separator.tsx
+++ b/src/components/ui/separator.tsx
@@ -1,0 +1,8 @@
+"use client";
+
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+export const Separator = ({ className, ...props }: React.HTMLAttributes<HTMLHRElement>) => (
+    <hr className={cn("ui-separator", className)} {...props} />
+);

--- a/src/components/ui/sheet.tsx
+++ b/src/components/ui/sheet.tsx
@@ -1,0 +1,84 @@
+"use client";
+
+import * as React from "react";
+import { createPortal } from "react-dom";
+import { cn } from "@/lib/utils";
+
+interface SheetContextValue {
+    open: boolean;
+    onOpenChange?: (open: boolean) => void;
+}
+
+const SheetContext = React.createContext<SheetContextValue | null>(null);
+
+export interface SheetProps {
+    open: boolean;
+    onOpenChange?: (open: boolean) => void;
+    children: React.ReactNode;
+}
+
+export const Sheet = ({ open, onOpenChange, children }: SheetProps) => {
+    const value = React.useMemo(() => ({ open, onOpenChange }), [open, onOpenChange]);
+    return <SheetContext.Provider value={value}>{children}</SheetContext.Provider>;
+};
+
+const useSheet = () => {
+    const context = React.useContext(SheetContext);
+    if (!context) {
+        throw new Error("Sheet components must be used within <Sheet>");
+    }
+    return context;
+};
+
+export const SheetTrigger = ({ className, ...props }: React.ButtonHTMLAttributes<HTMLButtonElement>) => (
+    <button type="button" className={cn("ui-sheet__trigger", className)} {...props} />
+);
+
+export const SheetContent = ({ className, children, ...props }: React.HTMLAttributes<HTMLDivElement>) => {
+    const { open, onOpenChange } = useSheet();
+    if (!open) return null;
+    return createPortal(
+        <div className="ui-sheet-overlay" role="presentation" onClick={() => onOpenChange?.(false)}>
+            <div className={cn("ui-sheet", className)} onClick={(event) => event.stopPropagation()} {...props}>
+                {children}
+            </div>
+        </div>,
+        document.body
+    );
+};
+
+export const SheetHeader = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+    <div className={cn("ui-sheet__header", className)} {...props} />
+);
+
+export const SheetFooter = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+    <div className={cn("ui-sheet__footer", className)} {...props} />
+);
+
+export const SheetTitle = ({ className, ...props }: React.HTMLAttributes<HTMLHeadingElement>) => (
+    <h2 className={cn("ui-sheet__title", className)} {...props} />
+);
+
+export const SheetDescription = ({ className, ...props }: React.HTMLAttributes<HTMLParagraphElement>) => (
+    <p className={cn("ui-sheet__description", className)} {...props} />
+);
+
+export const SheetClose = React.forwardRef<HTMLButtonElement, React.ButtonHTMLAttributes<HTMLButtonElement>>(
+    ({ className, ...props }, ref) => {
+        const { onOpenChange } = useSheet();
+        return (
+            <button
+                ref={ref}
+                type="button"
+                className={cn("ui-sheet__close", className)}
+                onClick={(event) => {
+                    props.onClick?.(event);
+                    onOpenChange?.(false);
+                }}
+                {...props}
+            />
+        );
+    }
+);
+
+SheetClose.displayName = "SheetClose";

--- a/src/components/ui/sidebar.tsx
+++ b/src/components/ui/sidebar.tsx
@@ -1,0 +1,20 @@
+"use client";
+
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+export const Sidebar = ({ className, ...props }: React.HTMLAttributes<HTMLElement>) => (
+    <aside className={cn("ui-sidebar", className)} {...props} />
+);
+
+export const SidebarHeader = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+    <div className={cn("ui-sidebar__header", className)} {...props} />
+);
+
+export const SidebarContent = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+    <div className={cn("ui-sidebar__content", className)} {...props} />
+);
+
+export const SidebarFooter = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+    <div className={cn("ui-sidebar__footer", className)} {...props} />
+);

--- a/src/components/ui/skeleton.tsx
+++ b/src/components/ui/skeleton.tsx
@@ -1,0 +1,8 @@
+"use client";
+
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+export const Skeleton = ({ className, style, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+    <div className={cn("ui-skeleton", className)} style={{ animation: "ui-pulse 1.5s ease-in-out infinite", ...style }} {...props} />
+);

--- a/src/components/ui/slider.tsx
+++ b/src/components/ui/slider.tsx
@@ -1,0 +1,15 @@
+"use client";
+
+import * as React from "react";
+
+export interface SliderProps extends React.InputHTMLAttributes<HTMLInputElement> {
+    min?: number;
+    max?: number;
+    step?: number;
+}
+
+export const Slider = React.forwardRef<HTMLInputElement, SliderProps>(({ min = 0, max = 100, step = 1, ...props }, ref) => (
+    <input ref={ref} type="range" min={min} max={max} step={step} {...props} />
+));
+
+Slider.displayName = "Slider";

--- a/src/components/ui/sonner.tsx
+++ b/src/components/ui/sonner.tsx
@@ -1,0 +1,3 @@
+"use client";
+
+export { Toaster as SonnerToaster } from "./toaster";

--- a/src/components/ui/switch.tsx
+++ b/src/components/ui/switch.tsx
@@ -1,0 +1,15 @@
+"use client";
+
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+export type SwitchProps = React.InputHTMLAttributes<HTMLInputElement>;
+
+export const Switch = React.forwardRef<HTMLInputElement, SwitchProps>(({ className, ...props }, ref) => (
+    <label className={cn("ui-switch", className)}>
+        <input ref={ref} type="checkbox" {...props} />
+        <span className="ui-switch__indicator" aria-hidden />
+    </label>
+));
+
+Switch.displayName = "Switch";

--- a/src/components/ui/table.tsx
+++ b/src/components/ui/table.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+export const Table = ({ className, ...props }: React.TableHTMLAttributes<HTMLTableElement>) => (
+    <table className={cn("ui-table", className)} {...props} />
+);
+
+export const TableHeader = ({ className, ...props }: React.HTMLAttributes<HTMLTableSectionElement>) => (
+    <thead className={cn("ui-table__header", className)} {...props} />
+);
+
+export const TableBody = ({ className, ...props }: React.HTMLAttributes<HTMLTableSectionElement>) => (
+    <tbody className={cn("ui-table__body", className)} {...props} />
+);
+
+export const TableRow = ({ className, ...props }: React.HTMLAttributes<HTMLTableRowElement>) => (
+    <tr className={cn("ui-table__row", className)} {...props} />
+);
+
+export const TableHead = ({ className, ...props }: React.ThHTMLAttributes<HTMLTableCellElement>) => (
+    <th className={cn("ui-table__head", className)} {...props} />
+);
+
+export const TableCell = ({ className, ...props }: React.TdHTMLAttributes<HTMLTableCellElement>) => (
+    <td className={cn("ui-table__cell", className)} {...props} />
+);
+
+export const TableCaption = ({ className, ...props }: React.HTMLAttributes<HTMLTableCaptionElement>) => (
+    <caption className={cn("ui-table__caption", className)} {...props} />
+);

--- a/src/components/ui/tabs.tsx
+++ b/src/components/ui/tabs.tsx
@@ -1,0 +1,97 @@
+"use client";
+
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+type TabsContextValue = {
+    value: string;
+    setValue: (value: string) => void;
+};
+
+const TabsContext = React.createContext<TabsContextValue | null>(null);
+
+export interface TabsProps extends React.HTMLAttributes<HTMLDivElement> {
+    defaultValue: string;
+    value?: string;
+    onValueChange?: (value: string) => void;
+}
+
+export const Tabs = ({ defaultValue, value, onValueChange, className, children, ...props }: TabsProps) => {
+    const [internalValue, setInternalValue] = React.useState(defaultValue);
+
+    const activeValue = value ?? internalValue;
+
+    const setValue = React.useCallback(
+        (next: string) => {
+            setInternalValue(next);
+            onValueChange?.(next);
+        },
+        [onValueChange]
+    );
+
+    const contextValue = React.useMemo(() => ({ value: activeValue, setValue }), [activeValue, setValue]);
+
+    React.useEffect(() => {
+        if (value !== undefined) {
+            setInternalValue(value);
+        }
+    }, [value]);
+
+    return (
+        <TabsContext.Provider value={contextValue}>
+            <div className={cn("ui-tabs", className)} {...props}>
+                {children}
+            </div>
+        </TabsContext.Provider>
+    );
+};
+
+const useTabs = () => {
+    const context = React.useContext(TabsContext);
+    if (!context) {
+        throw new Error("Tabs components must be used inside <Tabs>");
+    }
+    return context;
+};
+
+export const TabsList = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+    <div className={cn("ui-tabs-list", className)} role="tablist" {...props} />
+);
+
+export interface TabsTriggerProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+    value: string;
+}
+
+export const TabsTrigger = React.forwardRef<HTMLButtonElement, TabsTriggerProps>(({ value, className, ...props }, ref) => {
+    const { value: activeValue, setValue } = useTabs();
+    const isActive = activeValue === value;
+    return (
+        <button
+            ref={ref}
+            type="button"
+            role="tab"
+            aria-selected={isActive}
+            data-state={isActive ? "active" : "inactive"}
+            className={cn("ui-tabs-trigger", className)}
+            onClick={(event) => {
+                props.onClick?.(event);
+                setValue(value);
+            }}
+            {...props}
+        />
+    );
+});
+
+TabsTrigger.displayName = "TabsTrigger";
+
+export interface TabsContentProps extends React.HTMLAttributes<HTMLDivElement> {
+    value: string;
+}
+
+export const TabsContent = ({ value, className, ...props }: TabsContentProps) => {
+    const { value: activeValue } = useTabs();
+    if (activeValue !== value) {
+        return null;
+    }
+    return <div role="tabpanel" className={cn("ui-tabs-content", className)} {...props} />;
+};

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -1,0 +1,12 @@
+"use client";
+
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+export type TextareaProps = React.TextareaHTMLAttributes<HTMLTextAreaElement>;
+
+export const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(({ className, ...props }, ref) => {
+    return <textarea ref={ref} className={cn("ui-textarea", className)} {...props} />;
+});
+
+Textarea.displayName = "Textarea";

--- a/src/components/ui/toast.tsx
+++ b/src/components/ui/toast.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import * as React from "react";
+import { cn } from "@/lib/utils";
+import type { ToastData } from "./use-toast";
+
+export interface ToastProps {
+    toast: Required<ToastData>;
+    onDismiss?: (id: string) => void;
+}
+
+export const Toast = ({ toast, onDismiss }: ToastProps) => {
+    React.useEffect(() => {
+        if (!toast.duration) return;
+        const timer = window.setTimeout(() => {
+            onDismiss?.(toast.id);
+        }, toast.duration);
+        return () => window.clearTimeout(timer);
+    }, [toast, onDismiss]);
+
+    return (
+        <div className={cn("ui-toast", toast.variant === "destructive" && "ui-toast--destructive")}
+            role="status"
+            aria-live="polite"
+        >
+            <div className="ui-toast__content">
+                {toast.title && <p className="ui-toast__title">{toast.title}</p>}
+                {toast.description && <p className="ui-toast__description">{toast.description}</p>}
+            </div>
+            <button type="button" className="ui-toast__close" onClick={() => onDismiss?.(toast.id)} aria-label="Dismiss notification">
+                ×
+            </button>
+        </div>
+    );
+};

--- a/src/components/ui/toaster.tsx
+++ b/src/components/ui/toaster.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import * as React from "react";
+import { Toast } from "./toast";
+import type { ToastData } from "./use-toast";
+import { useToastListener } from "./use-toast";
+
+export const Toaster = () => {
+    const [toasts, setToasts] = React.useState<Required<ToastData>[]>([]);
+
+    useToastListener((action) => {
+        if (action.type === "ADD") {
+            setToasts((prev) => [...prev.filter((toast) => toast.id !== action.toast.id), action.toast]);
+        } else if (action.type === "DISMISS") {
+            setToasts((prev) => {
+                if (action.id) {
+                    return prev.filter((toast) => toast.id !== action.id);
+                }
+                return [];
+            });
+        }
+    });
+
+    const handleDismiss = React.useCallback((id: string) => {
+        setToasts((prev) => prev.filter((toast) => toast.id !== id));
+    }, []);
+
+    if (toasts.length === 0) {
+        return null;
+    }
+
+    return (
+        <div className="ui-toaster" role="region" aria-live="polite" aria-label="Notifications">
+            {toasts.map((toast) => (
+                <Toast key={toast.id} toast={toast} onDismiss={handleDismiss} />
+            ))}
+        </div>
+    );
+};

--- a/src/components/ui/toggle-group.tsx
+++ b/src/components/ui/toggle-group.tsx
@@ -1,0 +1,85 @@
+"use client";
+
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+interface ToggleGroupContextValue {
+    value: string[];
+    setValue: (value: string[]) => void;
+    type: "single" | "multiple";
+}
+
+const ToggleGroupContext = React.createContext<ToggleGroupContextValue | null>(null);
+
+export interface ToggleGroupProps extends React.HTMLAttributes<HTMLDivElement> {
+    type?: "single" | "multiple";
+    value?: string[];
+    defaultValue?: string[];
+    onValueChange?: (value: string[]) => void;
+}
+
+export const ToggleGroup = ({
+    type = "single",
+    value,
+    defaultValue,
+    onValueChange,
+    className,
+    children,
+    ...props
+}: ToggleGroupProps) => {
+    const [internal, setInternal] = React.useState<string[]>(defaultValue ?? []);
+    const current = value ?? internal;
+
+    const setValue = React.useCallback(
+        (next: string[]) => {
+            setInternal(next);
+            onValueChange?.(next);
+        },
+        [onValueChange]
+    );
+
+    return (
+        <ToggleGroupContext.Provider value={{ value: current, setValue, type }}>
+            <div className={cn("ui-toggle-group", className)} role="group" {...props}>
+                {children}
+            </div>
+        </ToggleGroupContext.Provider>
+    );
+};
+
+const useToggleGroup = () => {
+    const context = React.useContext(ToggleGroupContext);
+    if (!context) {
+        throw new Error("ToggleGroupItem must be used within <ToggleGroup>");
+    }
+    return context;
+};
+
+export interface ToggleGroupItemProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+    value: string;
+}
+
+export const ToggleGroupItem = React.forwardRef<HTMLButtonElement, ToggleGroupItemProps>(({ value, className, ...props }, ref) => {
+    const { value: selected, setValue, type } = useToggleGroup();
+    const isActive = selected.includes(value);
+    return (
+        <button
+            ref={ref}
+            type="button"
+            className={cn("ui-toggle-group__item", isActive && "is-active", className)}
+            aria-pressed={isActive}
+            onClick={(event) => {
+                props.onClick?.(event);
+                if (type === "single") {
+                    setValue(isActive ? [] : [value]);
+                } else {
+                    const next = isActive ? selected.filter((item) => item !== value) : [...selected, value];
+                    setValue(next);
+                }
+            }}
+            {...props}
+        />
+    );
+});
+
+ToggleGroupItem.displayName = "ToggleGroupItem";

--- a/src/components/ui/toggle.tsx
+++ b/src/components/ui/toggle.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+export interface ToggleProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+    pressed?: boolean;
+    onPressedChange?: (pressed: boolean) => void;
+}
+
+export const Toggle = React.forwardRef<HTMLButtonElement, ToggleProps>(
+    ({ pressed, onPressedChange, className, children, ...props }, ref) => {
+        const [internal, setInternal] = React.useState(false);
+        const isPressed = pressed ?? internal;
+        return (
+            <button
+                ref={ref}
+                type="button"
+                className={cn("ui-toggle", isPressed && "is-active", className)}
+                aria-pressed={isPressed}
+                onClick={(event) => {
+                    props.onClick?.(event);
+                    const next = !isPressed;
+                    setInternal(next);
+                    onPressedChange?.(next);
+                }}
+                {...props}
+            >
+                {children}
+            </button>
+        );
+    }
+);
+
+Toggle.displayName = "Toggle";

--- a/src/components/ui/tooltip.tsx
+++ b/src/components/ui/tooltip.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+interface TooltipContextValue {
+    open: boolean;
+    setOpen: (open: boolean) => void;
+}
+
+const TooltipContext = React.createContext<TooltipContextValue | null>(null);
+
+export interface TooltipProps {
+    children: React.ReactNode;
+}
+
+export const Tooltip = ({ children }: TooltipProps) => {
+    const [open, setOpen] = React.useState(false);
+
+    return (
+        <TooltipContext.Provider value={{ open, setOpen }}>
+            <span className="ui-tooltip" onMouseLeave={() => setOpen(false)}>
+                {children}
+            </span>
+        </TooltipContext.Provider>
+    );
+};
+
+const useTooltip = () => {
+    const context = React.useContext(TooltipContext);
+    if (!context) {
+        throw new Error("Tooltip components must be used inside <Tooltip>");
+    }
+    return context;
+};
+
+export const TooltipTrigger = ({ children }: { children: React.ReactNode }) => {
+    const { setOpen } = useTooltip();
+    return (
+        <span
+            className="ui-tooltip__trigger"
+            onMouseEnter={() => setOpen(true)}
+            onFocus={() => setOpen(true)}
+            onBlur={() => setOpen(false)}
+        >
+            {children}
+        </span>
+    );
+};
+
+export const TooltipContent = ({ className, children, ...props }: React.HTMLAttributes<HTMLDivElement>) => {
+    const { open } = useTooltip();
+    if (!open) return null;
+    return (
+        <div className={cn("ui-tooltip__content", className)} role="tooltip" {...props}>
+            {children}
+        </div>
+    );
+};

--- a/src/components/ui/use-toast.ts
+++ b/src/components/ui/use-toast.ts
@@ -1,0 +1,55 @@
+"use client";
+
+import * as React from "react";
+
+export type ToastVariant = "default" | "destructive";
+
+export interface ToastData {
+    id?: string;
+    title?: string;
+    description?: string;
+    duration?: number;
+    variant?: ToastVariant;
+}
+
+type ToastAction = { type: "ADD"; toast: Required<ToastData> }; // id required after creation
+
+const listeners = new Set<(action: ToastAction | { type: "DISMISS"; id?: string }) => void>();
+
+const createId = () => Math.random().toString(36).slice(2);
+
+const notify = (action: ToastAction | { type: "DISMISS"; id?: string }) => {
+    listeners.forEach((listener) => listener(action));
+};
+
+export const useToast = () => {
+    const toast = React.useCallback((data: ToastData) => {
+        const id = data.id ?? createId();
+        const payload: Required<ToastData> = {
+            id,
+            title: data.title ?? "",
+            description: data.description ?? "",
+            duration: data.duration ?? 4000,
+            variant: data.variant ?? "default",
+        };
+        notify({ type: "ADD", toast: payload });
+        return payload;
+    }, []);
+
+    const dismiss = React.useCallback((id?: string) => {
+        notify({ type: "DISMISS", id });
+    }, []);
+
+    return { toast, dismiss };
+};
+
+export const useToastListener = (
+    listener: (action: ToastAction | { type: "DISMISS"; id?: string }) => void
+) => {
+    React.useEffect(() => {
+        listeners.add(listener);
+        return () => {
+            listeners.delete(listener);
+        };
+    }, [listener]);
+};

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,0 +1,20 @@
+export type ClassValue = string | number | null | false | undefined | ClassValue[] | { [key: string]: boolean | string | number | undefined | null };
+
+const toArray = (value: ClassValue): string[] => {
+    if (!value) {
+        return [];
+    }
+    if (typeof value === "string" || typeof value === "number") {
+        return [String(value)];
+    }
+    if (Array.isArray(value)) {
+        return value.flatMap(toArray);
+    }
+    return Object.entries(value)
+        .filter(([, v]) => Boolean(v))
+        .map(([key]) => key);
+};
+
+export const cn = (...values: ClassValue[]): string => {
+    return values.flatMap(toArray).join(" ").trim();
+};


### PR DESCRIPTION
## Summary
- introduce a reusable UI component library (buttons, dialog, tabs, inputs, toast, etc.) under `src/components/ui`
- implement the Add Job modal with link, text, and voice ingestion flows plus toast feedback and dedicated styling
- integrate the modal into the tracker board, hook up job creation logic, and surface the toaster in the app layout

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e2a8fa9fc08325a575b3430d00a442