### PR TITLE
feat: add rich modal composer for feed posts

### DIFF
--- a/src/app/home/home.css
+++ b/src/app/home/home.css
@@ -78,66 +78,81 @@
   box-shadow: 0 20px 50px rgba(15, 23, 42, 0.08);
 }
 
+
 .home-compose-card {
-  padding: 28px 30px;
+  padding: 26px 28px;
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.home-compose-card__launcher {
   display: grid;
-  gap: 22px;
+  grid-template-columns: auto 1fr auto;
+  gap: 16px;
+  align-items: center;
+  padding: 16px 18px;
+  border-radius: 18px;
+  border: 1px dashed rgba(99, 102, 241, 0.28);
+  background: rgba(248, 250, 252, 0.85);
+  cursor: pointer;
+  transition: border-color 0.2s ease, transform 0.2s ease, box-shadow 0.2s ease;
 }
 
-.home-compose-card__header h2 {
-  margin: 0;
-  font-size: 1.25rem;
-  color: #111827;
+.home-compose-card__launcher:hover,
+.home-compose-card__launcher:focus-visible {
+  border-color: rgba(99, 102, 241, 0.6);
+  box-shadow: 0 12px 28px rgba(99, 102, 241, 0.12);
+  outline: none;
+  transform: translateY(-1px);
+}
+
+.home-compose-card__avatar {
+  width: 58px;
+  height: 58px;
+  border-radius: 50%;
+  background: linear-gradient(135deg, #6366f1, #ec4899);
+  color: #ffffff;
   font-weight: 700;
+  font-size: 1.1rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
 }
 
-.home-compose-card__header p {
-  margin: 6px 0 0;
-  color: #4b5563;
-  font-size: 0.95rem;
+.home-compose-card__launch-text {
+  display: grid;
+  gap: 4px;
 }
 
-.home-compose-tabs {
+.home-compose-card__prompt {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 600;
+  color: #1f2937;
+}
+
+.home-compose-card__hint {
+  margin: 0;
+  font-size: 0.9rem;
+  color: #6b7280;
+}
+
+.home-compose-card__launch-icon {
+  width: 34px;
+  height: 34px;
+  border-radius: 50%;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(99, 102, 241, 0.12);
+  color: #6366f1;
+}
+
+.home-compose-card__quick-tags {
   display: flex;
   flex-wrap: wrap;
   gap: 12px;
-}
-
-.home-compose-tab {
-  appearance: none;
-  border: 1px solid rgba(99, 102, 241, 0.15);
-  background: rgba(248, 250, 252, 0.9);
-  color: #4b5563;
-  font-weight: 600;
-  border-radius: 999px;
-  padding: 10px 18px;
-  display: inline-flex;
-  align-items: center;
-  gap: 10px;
-  cursor: pointer;
-  transition: background 0.2s ease, color 0.2s ease, transform 0.2s ease;
-}
-
-.home-compose-tab--active {
-  background: linear-gradient(135deg, #6366f1, #8b5cf6);
-  color: #ffffff;
-  border-color: transparent;
-  box-shadow: 0 14px 30px rgba(99, 102, 241, 0.25);
-}
-
-.home-compose-tab--disabled {
-  opacity: 0.6;
-}
-
-.home-compose-tab__icon {
-  width: 18px;
-  height: 18px;
-}
-
-.home-compose-card__body {
-  display: grid;
-  grid-template-columns: auto 1fr;
-  gap: 16px;
 }
 
 .home-avatar {
@@ -160,44 +175,6 @@
   box-shadow: none;
 }
 
-.home-compose-card__textarea {
-  width: 100%;
-  border-radius: 18px;
-  padding: 16px 18px;
-  border: 1px solid rgba(148, 163, 184, 0.4);
-  background: rgba(248, 250, 252, 0.9);
-  resize: vertical;
-  font-size: 1rem;
-  color: #111827;
-  font-family: inherit;
-  transition: border-color 0.2s ease, box-shadow 0.2s ease;
-}
-
-.home-compose-card__textarea:focus {
-  outline: none;
-  border-color: rgba(99, 102, 241, 0.6);
-  box-shadow: 0 0 0 3px rgba(99, 102, 241, 0.15);
-}
-
-.home-compose-card__textarea:disabled {
-  opacity: 0.5;
-  cursor: not-allowed;
-}
-
-.home-compose-card__footer {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 16px;
-  justify-content: space-between;
-  align-items: center;
-}
-
-.home-compose-tags {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 12px;
-}
-
 .home-tag-button {
   appearance: none;
   border-radius: 999px;
@@ -217,6 +194,404 @@
 .home-tag-button:hover {
   transform: translateY(-1px);
   border-color: rgba(99, 102, 241, 0.4);
+}
+
+.home-tag-button__icon {
+  width: 16px;
+  height: 16px;
+}
+
+.home-composer-modal__overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(15, 23, 42, 0.45);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+  z-index: 1000;
+}
+
+.home-composer-modal {
+  width: min(760px, calc(100% - 32px));
+  max-height: min(90vh, 760px);
+  border-radius: 28px;
+  background: #ffffff;
+  border: 1px solid rgba(99, 102, 241, 0.15);
+  box-shadow: 0 30px 70px rgba(15, 23, 42, 0.2);
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.home-composer-modal__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 24px 28px 0;
+}
+
+.home-composer-modal__header h2 {
+  margin: 0;
+  font-size: 1.4rem;
+  color: #111827;
+}
+
+.home-composer-modal__close {
+  border: none;
+  background: rgba(99, 102, 241, 0.12);
+  color: #4f46e5;
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.home-composer-modal__close:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 10px 20px rgba(99, 102, 241, 0.24);
+}
+
+.home-composer-modal__body {
+  padding: 24px 28px;
+  display: grid;
+  gap: 28px;
+  overflow-y: auto;
+}
+
+.home-composer-section {
+  display: grid;
+  gap: 18px;
+}
+
+.home-composer-section__header h3 {
+  margin: 0;
+  font-size: 1.05rem;
+  color: #111827;
+}
+
+.home-composer-section__header p {
+  margin: 6px 0 0;
+  color: #6b7280;
+  font-size: 0.9rem;
+}
+
+.home-composer-topics {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.home-topic-pill {
+  appearance: none;
+  border-radius: 999px;
+  border: 1px solid rgba(148, 163, 184, 0.4);
+  background: rgba(248, 250, 252, 0.9);
+  color: #374151;
+  padding: 10px 18px;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: border-color 0.2s ease, transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.home-topic-pill:hover,
+.home-topic-pill:focus-visible {
+  border-color: rgba(99, 102, 241, 0.5);
+  transform: translateY(-1px);
+  outline: none;
+}
+
+.home-topic-pill--active {
+  border-color: transparent;
+  background: linear-gradient(135deg, #6366f1, #8b5cf6);
+  color: #ffffff;
+  box-shadow: 0 14px 32px rgba(99, 102, 241, 0.28);
+}
+
+.home-composer-custom-topic {
+  display: grid;
+  gap: 6px;
+}
+
+.home-composer-tabs {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.3);
+  padding-bottom: 12px;
+}
+
+.home-composer-tab-trigger {
+  appearance: none;
+  border: none;
+  background: rgba(248, 250, 252, 0.9);
+  color: #4b5563;
+  padding: 10px 18px;
+  border-radius: 999px;
+  font-weight: 600;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  cursor: pointer;
+  transition: background 0.2s ease, color 0.2s ease, transform 0.2s ease;
+}
+
+.home-composer-tab-trigger[data-state="active"] {
+  background: linear-gradient(135deg, #6366f1, #8b5cf6);
+  color: #ffffff;
+  box-shadow: 0 14px 30px rgba(99, 102, 241, 0.2);
+}
+
+.home-composer-tabpanel {
+  display: grid;
+  gap: 18px;
+  padding-top: 18px;
+}
+
+.home-composer-editor {
+  border: 1px solid rgba(148, 163, 184, 0.45);
+  border-radius: 18px;
+  background: rgba(248, 250, 252, 0.85);
+  display: grid;
+  gap: 12px;
+  padding: 16px;
+}
+
+.home-composer-editor__input {
+  min-height: 160px;
+  max-height: 260px;
+  overflow-y: auto;
+  outline: none;
+  border: none;
+  font-size: 1rem;
+  color: #1f2937;
+  line-height: 1.6;
+}
+
+.home-composer-editor__input:empty::before {
+  content: attr(data-placeholder);
+  color: #9ca3af;
+}
+
+.home-composer-toolbar {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.home-composer-toolbar button {
+  border: none;
+  background: rgba(99, 102, 241, 0.1);
+  color: #4f46e5;
+  width: 32px;
+  height: 32px;
+  border-radius: 8px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.home-composer-toolbar button:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 10px 20px rgba(99, 102, 241, 0.18);
+}
+
+.home-composer-toolbar__emoji {
+  position: relative;
+}
+
+.home-composer-toolbar__emoji-popover {
+  position: absolute;
+  top: calc(100% + 8px);
+  right: 0;
+  display: grid;
+  grid-template-columns: repeat(8, 1fr);
+  gap: 6px;
+  padding: 8px;
+  background: #ffffff;
+  border-radius: 16px;
+  box-shadow: 0 16px 40px rgba(15, 23, 42, 0.18);
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.2s ease;
+  z-index: 10;
+}
+
+.home-composer-toolbar__emoji:hover .home-composer-toolbar__emoji-popover,
+.home-composer-toolbar__emoji:focus-within .home-composer-toolbar__emoji-popover {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.home-composer-toolbar__emoji-popover button {
+  width: 28px;
+  height: 28px;
+  border-radius: 8px;
+  border: none;
+  background: transparent;
+  font-size: 1rem;
+}
+
+.home-composer-editor-meta {
+  display: flex;
+  justify-content: space-between;
+  font-size: 0.85rem;
+  color: #6b7280;
+}
+
+.home-composer-attachment-button {
+  appearance: none;
+  border: 1px dashed rgba(99, 102, 241, 0.4);
+  background: rgba(248, 250, 252, 0.8);
+  color: #4f46e5;
+  font-weight: 600;
+  padding: 12px 16px;
+  border-radius: 14px;
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  cursor: pointer;
+  transition: border-color 0.2s ease, transform 0.2s ease;
+}
+
+.home-composer-attachment-button:hover {
+  border-color: rgba(79, 70, 229, 0.7);
+  transform: translateY(-1px);
+}
+
+.home-composer-attachments {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 12px;
+}
+
+.home-composer-attachment {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  background: rgba(248, 250, 252, 0.9);
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  border-radius: 14px;
+  padding: 12px 16px;
+  gap: 14px;
+}
+
+.home-composer-attachment__name {
+  margin: 0;
+  font-weight: 600;
+  color: #1f2937;
+}
+
+.home-composer-attachment__meta {
+  margin: 0;
+  font-size: 0.85rem;
+  color: #6b7280;
+}
+
+.home-composer-attachment__info {
+  display: grid;
+  gap: 4px;
+}
+
+.home-composer-attachment__remove {
+  border: none;
+  background: rgba(248, 113, 113, 0.12);
+  color: #b91c1c;
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+}
+
+.home-composer-attachment__remove:hover {
+  background: rgba(248, 113, 113, 0.24);
+}
+
+.home-composer-poll {
+  display: grid;
+  gap: 16px;
+  padding: 18px;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  border-radius: 18px;
+  background: rgba(248, 250, 252, 0.9);
+}
+
+.home-composer-poll-options {
+  display: grid;
+  gap: 12px;
+}
+
+.home-composer-poll-option {
+  display: flex;
+  gap: 10px;
+  align-items: center;
+}
+
+.home-composer-poll-remove {
+  border: none;
+  background: rgba(248, 113, 113, 0.12);
+  color: #b91c1c;
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+}
+
+.home-composer-poll-remove:hover {
+  background: rgba(248, 113, 113, 0.24);
+}
+
+.home-composer-poll-add {
+  justify-self: flex-start;
+}
+
+.home-composer-poll-multi {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 0.9rem;
+  color: #4b5563;
+}
+
+.home-composer-error {
+  margin: 0;
+  color: #b91c1c;
+  font-size: 0.9rem;
+}
+
+.home-composer-modal__footer {
+  padding: 16px 28px 28px;
+  display: flex;
+  justify-content: flex-end;
+  gap: 12px;
+  border-top: 1px solid rgba(148, 163, 184, 0.2);
+}
+
+.home-composer-file-input {
+  position: absolute;
+  width: 0;
+  height: 0;
+  opacity: 0;
+  pointer-events: none;
 }
 
 .home-tag-button--active {

--- a/src/components/feed/FeedComposer.tsx
+++ b/src/components/feed/FeedComposer.tsx
@@ -1,95 +1,74 @@
-import { Loader2 } from "lucide-react";
+import type { KeyboardEventHandler } from "react";
 
-import type { ComposerTab, ComposerTabKey, QuickTag } from "./types";
-import { classNames, initialsFromName } from "./utils";
+import { ChevronRight } from "lucide-react";
+
+import type { QuickTag } from "./types";
+import { initialsFromName } from "./utils";
 
 interface FeedComposerProps {
-  composerTabs: ComposerTab[];
+  onOpen: () => void;
   quickTags: QuickTag[];
-  activeTab: ComposerTabKey;
-  onTabChange: (tab: ComposerTabKey) => void;
-  disabledTabReason?: string | null;
-  composerText: string;
-  onTextChange: (value: string) => void;
-  placeholder: string;
-  composerError?: string | null;
-  selectedTag: string | null;
-  onSelectTag: (value: string | null) => void;
-  onSubmit: () => void;
-  canSubmit: boolean;
-  isSubmitting: boolean;
+  lastSelectedTag?: string | null;
   currentUserName?: string;
 }
 
 export const FeedComposer = ({
-  composerTabs,
+  onOpen,
   quickTags,
-  activeTab,
-  onTabChange,
-  disabledTabReason,
-  composerText,
-  onTextChange,
-  placeholder,
-  composerError,
-  selectedTag,
-  onSelectTag,
-  onSubmit,
-  canSubmit,
-  isSubmitting,
+  lastSelectedTag,
   currentUserName = "User",
 }: FeedComposerProps) => {
-  return (
-    <article className="home-compose-card" aria-label="Share an update">
+  const handleKeyDown: KeyboardEventHandler<HTMLDivElement> = (event) => {
+    if (event.key === "Enter" || event.key === " ") {
+      event.preventDefault();
+      onOpen();
+    }
+  };
 
-      <div className="home-compose-card__body">
-        <div className="home-avatar" aria-hidden>
+  const preferredTagLabel = quickTags.find((tag) => tag.value === lastSelectedTag)?.label;
+
+  return (
+    <article className="home-compose-card" aria-label="Create a post">
+      <div
+        className="home-compose-card__launcher"
+        role="button"
+        tabIndex={0}
+        onClick={onOpen}
+        onKeyDown={handleKeyDown}
+        aria-pressed="false"
+      >
+        <div className="home-compose-card__avatar" aria-hidden>
           {initialsFromName(currentUserName)}
         </div>
-        <textarea
-          value={composerText}
-          onChange={(event) => onTextChange(event.target.value)}
-          className="home-compose-card__textarea"
-          placeholder={placeholder}
-          disabled={activeTab !== "update"}
-          aria-label="What’s new?"
-          maxLength={800}
-        />
+        <div className="home-compose-card__launch-text">
+          <p className="home-compose-card__prompt">Share your progress with the community…</p>
+          <p className="home-compose-card__hint">
+            {preferredTagLabel
+              ? `Last topic: ${preferredTagLabel}`
+              : "Pick a topic and add updates, media, polls, or files."}
+          </p>
+        </div>
+        <div className="home-compose-card__launch-icon" aria-hidden>
+          <ChevronRight />
+        </div>
       </div>
 
-      <footer className="home-compose-card__footer">
-        <div className="home-compose-tabs" role="tablist" aria-label="Share options">
-          {composerTabs.map(({ key, label, icon: Icon, disabled }) => {
-            const isActive = activeTab === key;
-            return (
-              <button
-                key={key}
-                type="button"
-                role="tab"
-                aria-selected={isActive}
-                className={classNames(
-                  "home-compose-tab",
-                  isActive && "home-compose-tab--active",
-                  disabled && "home-compose-tab--disabled",
-                )}
-                onClick={() => onTabChange(key)}
-              >
-                <Icon className="home-compose-tab__icon" aria-hidden />
-                {label}
-              </button>
-            );
-          })}
-        </div>
-
-        <div className="home-compose-actions">
-          {composerError && (
-            <p className="home-compose-error" role="alert">
-              {composerError}
-            </p>
-          )}
-
-          {disabledTabReason && <p className="home-compose-hint">{disabledTabReason}</p>}
-        </div>
-      </footer>
+      {quickTags.length > 0 && (
+        <footer className="home-compose-card__quick-tags" aria-label="Suggested topics">
+          {quickTags.map(({ label, value, icon: Icon }) => (
+            <button
+              key={value}
+              type="button"
+              className="home-tag-button"
+              onClick={onOpen}
+              aria-label={`Share an update about ${label}`}
+            >
+              <Icon className="home-tag-button__icon" aria-hidden />
+              {label}
+            </button>
+          ))}
+        </footer>
+      )}
     </article>
   );
 };

--- a/src/components/feed/FeedComposerModal.tsx
+++ b/src/components/feed/FeedComposerModal.tsx
@@ -1,0 +1,773 @@
+"use client";
+
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ChangeEvent,
+} from "react";
+
+import {
+  Bold,
+  Image as ImageIcon,
+  Italic,
+  Paperclip,
+  Plus,
+  Smile,
+  Trash2,
+  Underline,
+  Video as VideoIcon,
+  X,
+} from "lucide-react";
+
+import type { CreatePostPayload } from "@/services/feed.service";
+
+import { Button } from "../ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "../ui/dialog";
+import { Input } from "../ui/input";
+import { Label } from "../ui/label";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "../ui/tabs";
+
+import type { ComposerTab, ComposerTabKey, QuickTag } from "./types";
+
+const COMPOSER_CHAR_LIMIT = 1400;
+const EMOJI_OPTIONS = [
+  "😀",
+  "😁",
+  "😂",
+  "😊",
+  "😍",
+  "🤩",
+  "🤔",
+  "😎",
+  "🙌",
+  "🔥",
+  "🎉",
+  "🚀",
+  "🌟",
+  "💡",
+  "✅",
+  "🥳",
+  "❤️",
+];
+
+type AttachmentKind = "image" | "video" | "file";
+
+interface AttachmentItem {
+  id: string;
+  file: File;
+  previewUrl: string;
+  kind: AttachmentKind;
+  name: string;
+  size: number;
+}
+
+export interface FeedComposerModalProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  composerTabs: ComposerTab[];
+  quickTags: QuickTag[];
+  isSubmitting: boolean;
+  initialTag?: string | null;
+  onSubmit: (
+    payload: CreatePostPayload
+  ) => Promise<{ success: boolean; error?: string }>;
+}
+
+const sanitizeHtml = (value: string) => {
+  if (typeof window === "undefined") {
+    return value;
+  }
+  const container = document.createElement("div");
+  container.innerHTML = value;
+  const allowedTags = new Set(["STRONG", "B", "EM", "I", "U", "BR"]);
+
+  const normalizeTag = (tagName: string) => {
+    if (tagName === "B") return "STRONG";
+    if (tagName === "I") return "EM";
+    return tagName;
+  };
+
+  const traverse = (node: Node) => {
+    if (node.nodeType === Node.ELEMENT_NODE) {
+      const element = node as HTMLElement;
+      const normalized = normalizeTag(element.tagName);
+      if (!allowedTags.has(normalized)) {
+        if (normalized === "DIV" || normalized === "P" || normalized === "SPAN") {
+          const fragment = document.createDocumentFragment();
+          while (element.firstChild) {
+            fragment.appendChild(element.firstChild);
+          }
+          element.replaceWith(fragment);
+        } else {
+          element.replaceWith(document.createTextNode(element.textContent ?? ""));
+          return;
+        }
+      } else {
+        const desiredTag = normalized.toLowerCase();
+        if (desiredTag !== element.tagName.toLowerCase()) {
+          const replacement = document.createElement(desiredTag);
+          while (element.firstChild) {
+            replacement.appendChild(element.firstChild);
+          }
+          element.replaceWith(replacement);
+          traverse(replacement);
+          return;
+        }
+        [...element.attributes].forEach((attribute) => element.removeAttribute(attribute.name));
+      }
+    }
+    [...node.childNodes].forEach(traverse);
+  };
+
+  [...container.childNodes].forEach(traverse);
+
+  return container.innerHTML
+    .replace(/<div><br><\/div>/gi, "<br>")
+    .replace(/<div>/gi, "<br>")
+    .replace(/<\/div>/gi, "")
+    .replace(/<p>/gi, "")
+    .replace(/<\/p>/gi, "<br>")
+    .replace(/(&nbsp;)+/gi, " ");
+};
+
+const stripHtml = (value: string) => {
+  if (typeof window === "undefined") {
+    return value;
+  }
+  const container = document.createElement("div");
+  container.innerHTML = value;
+  return container.textContent ?? container.innerText ?? "";
+};
+
+const readFileAsDataUrl = (file: File) =>
+  new Promise<string>((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => {
+      if (typeof reader.result === "string") {
+        resolve(reader.result);
+      } else {
+        reject(new Error("Unable to read file"));
+      }
+    };
+    reader.onerror = () => reject(reader.error ?? new Error("Failed to read file"));
+    reader.readAsDataURL(file);
+  });
+
+export const FeedComposerModal = ({
+  open,
+  onOpenChange,
+  composerTabs,
+  quickTags,
+  isSubmitting,
+  initialTag,
+  onSubmit,
+}: FeedComposerModalProps) => {
+  const [activeTab, setActiveTab] = useState<ComposerTabKey>("update");
+  const [editorHtml, setEditorHtml] = useState("");
+  const [plainText, setPlainText] = useState("");
+  const [selectedTopic, setSelectedTopic] = useState<string | null>(
+    initialTag ?? quickTags[0]?.value ?? null
+  );
+  const [customTopic, setCustomTopic] = useState<string>("");
+  const [imageAttachments, setImageAttachments] = useState<AttachmentItem[]>([]);
+  const [videoAttachments, setVideoAttachments] = useState<AttachmentItem[]>([]);
+  const [fileAttachments, setFileAttachments] = useState<AttachmentItem[]>([]);
+  const [pollQuestion, setPollQuestion] = useState("");
+  const [pollOptions, setPollOptions] = useState<string[]>(["", ""]);
+  const [allowMultiplePollOptions, setAllowMultiplePollOptions] = useState(false);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  const imageInputRef = useRef<HTMLInputElement | null>(null);
+  const videoInputRef = useRef<HTMLInputElement | null>(null);
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
+
+  const releaseAttachmentUrls = useCallback((attachments: AttachmentItem[]) => {
+    attachments.forEach((item) => URL.revokeObjectURL(item.previewUrl));
+  }, []);
+
+  const resetAttachments = useCallback(() => {
+    setImageAttachments((previous) => {
+      releaseAttachmentUrls(previous);
+      return [];
+    });
+    setVideoAttachments((previous) => {
+      releaseAttachmentUrls(previous);
+      return [];
+    });
+    setFileAttachments((previous) => {
+      releaseAttachmentUrls(previous);
+      return [];
+    });
+  }, [releaseAttachmentUrls]);
+
+  const resetComposer = useCallback(() => {
+    setActiveTab("update");
+    setEditorHtml("");
+    setPlainText("");
+    setPollQuestion("");
+    setPollOptions(["", ""]);
+    setAllowMultiplePollOptions(false);
+    setErrorMessage(null);
+    resetAttachments();
+
+    const fallback = quickTags[0]?.value ?? null;
+    setSelectedTopic(initialTag ?? fallback);
+    const shouldUseCustom = initialTag && !quickTags.some((tag) => tag.value === initialTag);
+    setCustomTopic(shouldUseCustom ? initialTag ?? "" : "");
+  }, [initialTag, quickTags, resetAttachments]);
+
+  useEffect(() => {
+    if (open) {
+      resetComposer();
+    } else {
+      resetAttachments();
+    }
+  }, [open, resetAttachments, resetComposer]);
+
+  useEffect(() => resetAttachments, [resetAttachments]);
+
+  const activeAttachments = useMemo(() => {
+    if (activeTab === "image") return imageAttachments;
+    if (activeTab === "video") return videoAttachments;
+    if (activeTab === "attach") return fileAttachments;
+    return [];
+  }, [activeTab, fileAttachments, imageAttachments, videoAttachments]);
+
+  const handleEditorChange = useCallback((value: string) => {
+    const sanitized = sanitizeHtml(value);
+    setEditorHtml(sanitized);
+    setPlainText(stripHtml(sanitized));
+  }, []);
+
+  const handleSelectTopic = useCallback((value: string) => {
+    setSelectedTopic(value);
+    setCustomTopic("");
+  }, []);
+
+  const handleCustomTopicChange = useCallback(
+    (event: ChangeEvent<HTMLInputElement>) => {
+      const { value } = event.target;
+      setCustomTopic(value);
+      const normalized = value.trim();
+      if (normalized.length > 0) {
+        setSelectedTopic(normalized);
+      } else {
+        setSelectedTopic(quickTags[0]?.value ?? null);
+      }
+    },
+    [quickTags]
+  );
+
+  const handleAddAttachments = useCallback(
+    (files: FileList | null, kind: AttachmentKind) => {
+      if (!files || files.length === 0) return;
+      const next = Array.from(files).map((file) => ({
+        id: `${kind}-${file.name}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+        file,
+        previewUrl: URL.createObjectURL(file),
+        kind,
+        name: file.name,
+        size: file.size,
+      }));
+
+      if (kind === "image") {
+        setImageAttachments((previous) => [...previous, ...next]);
+      } else if (kind === "video") {
+        setVideoAttachments((previous) => [...previous, ...next]);
+      } else {
+        setFileAttachments((previous) => [...previous, ...next]);
+      }
+    },
+    []
+  );
+
+  const handleRemoveAttachment = useCallback((id: string, kind: AttachmentKind) => {
+    const removeFrom = (items: AttachmentItem[]) => {
+      let removed: AttachmentItem | undefined;
+      const filtered = items.filter((item) => {
+        if (item.id === id) {
+          removed = item;
+          return false;
+        }
+        return true;
+      });
+      if (removed) {
+        URL.revokeObjectURL(removed.previewUrl);
+      }
+      return filtered;
+    };
+
+    if (kind === "image") {
+      setImageAttachments((previous) => removeFrom(previous));
+    } else if (kind === "video") {
+      setVideoAttachments((previous) => removeFrom(previous));
+    } else {
+      setFileAttachments((previous) => removeFrom(previous));
+    }
+  }, []);
+
+  const handlePollOptionChange = useCallback((index: number, value: string) => {
+    setPollOptions((previous) => {
+      const next = [...previous];
+      next[index] = value;
+      return next;
+    });
+  }, []);
+
+  const handleAddPollOption = useCallback(() => {
+    setPollOptions((previous) => [...previous, ""]);
+  }, []);
+
+  const handleRemovePollOption = useCallback((index: number) => {
+    setPollOptions((previous) => {
+      if (previous.length <= 2) return previous;
+      const next = [...previous];
+      next.splice(index, 1);
+      return next;
+    });
+  }, []);
+
+  const handleSubmitInternal = useCallback(async () => {
+    if (isSubmitting) return;
+
+    const trimmedText = plainText.trim();
+
+    if (!selectedTopic) {
+      setErrorMessage("Choose a topic before sharing.");
+      return;
+    }
+
+    if (activeTab === "update" && trimmedText.length === 0) {
+      setErrorMessage("Share a few words about your progress.");
+      return;
+    }
+
+    if (plainText.length > COMPOSER_CHAR_LIMIT) {
+      setErrorMessage("Please keep your update within the character limit.");
+      return;
+    }
+
+    if (activeTab === "image" && imageAttachments.length === 0) {
+      setErrorMessage("Add at least one image to continue.");
+      return;
+    }
+
+    if (activeTab === "video" && videoAttachments.length === 0) {
+      setErrorMessage("Add at least one video to continue.");
+      return;
+    }
+
+    if (activeTab === "attach" && fileAttachments.length === 0) {
+      setErrorMessage("Attach at least one file to continue.");
+      return;
+    }
+
+    if (activeTab === "poll") {
+      const options = pollOptions.map((option) => option.trim()).filter(Boolean);
+      if (!pollQuestion.trim()) {
+        setErrorMessage("Ask a question for your poll.");
+        return;
+      }
+      if (options.length < 2) {
+        setErrorMessage("Provide at least two poll options.");
+        return;
+      }
+    }
+
+    setErrorMessage(null);
+
+    const typeMap: Record<ComposerTabKey, string> = {
+      update: "text",
+      image: "image",
+      video: "video",
+      poll: "poll",
+      attach: "attachment",
+    };
+
+    const tags = selectedTopic ? [selectedTopic] : [];
+
+    const payload: CreatePostPayload = {
+      type: typeMap[activeTab],
+      text: trimmedText,
+      tags: tags.length > 0 ? tags : undefined,
+      visibility: "public",
+    };
+
+    if (activeTab === "poll") {
+      payload.poll = {
+        prompt: pollQuestion.trim(),
+        options: pollOptions.map((option) => option.trim()).filter(Boolean),
+        multiSelect: allowMultiplePollOptions || undefined,
+      };
+    }
+
+    if (activeAttachments.length > 0) {
+      const attachmentsPayload = await Promise.all(
+        activeAttachments.map(async (item) => ({
+          kind: item.kind,
+          url: await readFileAsDataUrl(item.file),
+          description: item.name,
+        }))
+      );
+      payload.media = attachmentsPayload;
+    }
+
+    const result = await onSubmit(payload);
+    if (!result.success && result.error) {
+      setErrorMessage(result.error);
+    } else if (result.success) {
+      resetComposer();
+    }
+  }, [
+    activeAttachments,
+    activeTab,
+    allowMultiplePollOptions,
+    fileAttachments,
+    imageAttachments,
+    isSubmitting,
+    onSubmit,
+    plainText,
+    pollOptions,
+    pollQuestion,
+    resetComposer,
+    selectedTopic,
+    videoAttachments,
+  ]);
+
+  const charactersRemaining = useMemo(
+    () => COMPOSER_CHAR_LIMIT - plainText.length,
+    [plainText.length]
+  );
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="home-composer-modal" overlayClassName="home-composer-modal__overlay">
+        <DialogHeader className="home-composer-modal__header">
+          <DialogTitle>Share Your Growth</DialogTitle>
+          <button
+            type="button"
+            className="home-composer-modal__close"
+            onClick={() => onOpenChange(false)}
+            aria-label="Close composer"
+          >
+            <X size={18} />
+          </button>
+        </DialogHeader>
+
+        <div className="home-composer-modal__body">
+          <section className="home-composer-section">
+            <header className="home-composer-section__header">
+              <h3>Choose a topic</h3>
+              <p>Every post needs a topic. Select one to help others find your update.</p>
+            </header>
+
+            <div className="home-composer-topics">
+              {quickTags.map(({ label, value, icon: Icon }) => {
+                const isActive = selectedTopic === value;
+                return (
+                  <button
+                    key={value}
+                    type="button"
+                    className={`home-topic-pill ${isActive ? "home-topic-pill--active" : ""}`}
+                    onClick={() => handleSelectTopic(value)}
+                  >
+                    <Icon size={16} aria-hidden />
+                    {label}
+                  </button>
+                );
+              })}
+            </div>
+
+            <div className="home-composer-custom-topic">
+              <Label htmlFor="composer-custom-topic">Custom topic</Label>
+              <Input
+                id="composer-custom-topic"
+                placeholder="Add your own tag"
+                value={customTopic}
+                onChange={handleCustomTopicChange}
+              />
+            </div>
+          </section>
+
+          <section className="home-composer-section">
+            <header className="home-composer-section__header">
+              <h3>Create your post</h3>
+              <p>Format text, add emoji, attach files, and preview everything here.</p>
+            </header>
+
+            <Tabs value={activeTab} onValueChange={(value) => setActiveTab(value as ComposerTabKey)}>
+              <TabsList className="home-composer-tabs">
+                {composerTabs.map(({ key, label, icon: Icon }) => (
+                  <TabsTrigger key={key} value={key} className="home-composer-tab-trigger">
+                    <Icon size={16} aria-hidden />
+                    {label}
+                  </TabsTrigger>
+                ))}
+              </TabsList>
+
+              <TabsContent value={activeTab} className="home-composer-tabpanel">
+                <RichTextEditor
+                  value={editorHtml}
+                  onChange={handleEditorChange}
+                  maxLength={COMPOSER_CHAR_LIMIT}
+                  placeholder="Share your progress, challenges, or what you're learning..."
+                />
+
+                <div className="home-composer-editor-meta">
+                  <span>
+                    {plainText.length}/{COMPOSER_CHAR_LIMIT} characters
+                  </span>
+                  <span>
+                    {charactersRemaining >= 0
+                      ? `${charactersRemaining} characters remaining`
+                      : "Character limit exceeded"}
+                  </span>
+                </div>
+
+                {activeTab === "image" && (
+                  <button
+                    type="button"
+                    className="home-composer-attachment-button"
+                    onClick={() => imageInputRef.current?.click()}
+                  >
+                    <ImageIcon size={16} /> Add images
+                  </button>
+                )}
+
+                {activeTab === "video" && (
+                  <button
+                    type="button"
+                    className="home-composer-attachment-button"
+                    onClick={() => videoInputRef.current?.click()}
+                  >
+                    <VideoIcon size={16} /> Add videos
+                  </button>
+                )}
+
+                {activeTab === "attach" && (
+                  <button
+                    type="button"
+                    className="home-composer-attachment-button"
+                    onClick={() => fileInputRef.current?.click()}
+                  >
+                    <Paperclip size={16} /> Attach files
+                  </button>
+                )}
+
+                {activeAttachments.length > 0 && (
+                  <ul className="home-composer-attachments">
+                    {activeAttachments.map((item) => (
+                      <li key={item.id} className="home-composer-attachment">
+                        <div className="home-composer-attachment__info">
+                          <p className="home-composer-attachment__name">{item.name}</p>
+                          <p className="home-composer-attachment__meta">
+                            {(item.size / 1024 / 1024).toFixed(2)} MB
+                          </p>
+                        </div>
+                        <button
+                          type="button"
+                          className="home-composer-attachment__remove"
+                          onClick={() => handleRemoveAttachment(item.id, item.kind)}
+                          aria-label={`Remove ${item.name}`}
+                        >
+                          <Trash2 size={16} />
+                        </button>
+                      </li>
+                    ))}
+                  </ul>
+                )}
+
+                {activeTab === "poll" && (
+                  <div className="home-composer-poll">
+                    <Label htmlFor="composer-poll-question">Poll question</Label>
+                    <Input
+                      id="composer-poll-question"
+                      placeholder="What do you want to ask?"
+                      value={pollQuestion}
+                      onChange={(event) => setPollQuestion(event.target.value)}
+                    />
+
+                    <div className="home-composer-poll-options">
+                      {pollOptions.map((option, index) => (
+                        <div key={`poll-option-${index}`} className="home-composer-poll-option">
+                          <Input
+                            placeholder={`Option ${index + 1}`}
+                            value={option}
+                            onChange={(event) => handlePollOptionChange(index, event.target.value)}
+                          />
+                          {pollOptions.length > 2 && (
+                            <button
+                              type="button"
+                              className="home-composer-poll-remove"
+                              onClick={() => handleRemovePollOption(index)}
+                              aria-label={`Remove option ${index + 1}`}
+                            >
+                              <Trash2 size={16} />
+                            </button>
+                          )}
+                        </div>
+                      ))}
+                    </div>
+
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      className="home-composer-poll-add"
+                      onClick={handleAddPollOption}
+                    >
+                      <Plus size={16} /> Add option
+                    </Button>
+
+                    <label className="home-composer-poll-multi">
+                      <input
+                        type="checkbox"
+                        checked={allowMultiplePollOptions}
+                        onChange={(event) => setAllowMultiplePollOptions(event.target.checked)}
+                      />
+                      Allow multiple selections
+                    </label>
+                  </div>
+                )}
+
+                {errorMessage && (
+                  <p className="home-composer-error" role="alert">
+                    {errorMessage}
+                  </p>
+                )}
+              </TabsContent>
+            </Tabs>
+          </section>
+        </div>
+
+        <footer className="home-composer-modal__footer">
+          <Button type="button" variant="ghost" onClick={() => onOpenChange(false)}>
+            Cancel
+          </Button>
+          <Button type="button" onClick={handleSubmitInternal} disabled={isSubmitting}>
+            {isSubmitting ? "Sharing..." : "Share progress"}
+          </Button>
+        </footer>
+
+        <input
+          ref={imageInputRef}
+          type="file"
+          accept="image/*"
+          className="home-composer-file-input"
+          multiple
+          onChange={(event) => handleAddAttachments(event.target.files, "image")}
+        />
+        <input
+          ref={videoInputRef}
+          type="file"
+          accept="video/*"
+          className="home-composer-file-input"
+          multiple
+          onChange={(event) => handleAddAttachments(event.target.files, "video")}
+        />
+        <input
+          ref={fileInputRef}
+          type="file"
+          className="home-composer-file-input"
+          multiple
+          onChange={(event) => handleAddAttachments(event.target.files, "file")}
+        />
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+interface RichTextEditorProps {
+  value: string;
+  onChange: (value: string) => void;
+  maxLength: number;
+  placeholder?: string;
+}
+
+const RichTextEditor = ({ value, onChange, maxLength, placeholder }: RichTextEditorProps) => {
+  const editorRef = useRef<HTMLDivElement | null>(null);
+  const lastValueRef = useRef(value);
+
+  useEffect(() => {
+    if (editorRef.current && editorRef.current.innerHTML !== value) {
+      editorRef.current.innerHTML = value;
+    }
+    lastValueRef.current = value;
+  }, [value]);
+
+  const handleInput = useCallback(() => {
+    if (!editorRef.current) return;
+    const nextValue = sanitizeHtml(editorRef.current.innerHTML);
+    const length = stripHtml(nextValue).length;
+    if (length > maxLength) {
+      editorRef.current.innerHTML = lastValueRef.current;
+      return;
+    }
+    lastValueRef.current = nextValue;
+    onChange(nextValue);
+  }, [maxLength, onChange]);
+
+  const applyCommand = useCallback((command: "bold" | "italic" | "underline") => {
+    if (typeof document === "undefined") return;
+    editorRef.current?.focus();
+    document.execCommand(command, false);
+    handleInput();
+  }, [handleInput]);
+
+  const insertEmoji = useCallback((emoji: string) => {
+    if (typeof document === "undefined") return;
+    editorRef.current?.focus();
+    document.execCommand("insertText", false, emoji);
+    handleInput();
+  }, [handleInput]);
+
+  return (
+    <div className="home-composer-editor">
+      <div
+        ref={editorRef}
+        className="home-composer-editor__input"
+        contentEditable
+        suppressContentEditableWarning
+        data-placeholder={placeholder}
+        data-home-composer-editor
+        onInput={handleInput}
+        onBlur={handleInput}
+        aria-multiline="true"
+        role="textbox"
+      />
+      <div className="home-composer-toolbar" role="toolbar" aria-label="Formatting options">
+        <button type="button" onClick={() => applyCommand("bold")} aria-label="Bold">
+          <Bold size={16} />
+        </button>
+        <button type="button" onClick={() => applyCommand("italic")} aria-label="Italic">
+          <Italic size={16} />
+        </button>
+        <button type="button" onClick={() => applyCommand("underline")} aria-label="Underline">
+          <Underline size={16} />
+        </button>
+        <div className="home-composer-toolbar__emoji">
+          <Smile size={16} aria-hidden />
+          <div className="home-composer-toolbar__emoji-popover">
+            {EMOJI_OPTIONS.map((emoji) => (
+              <button
+                key={emoji}
+                type="button"
+                onClick={() => insertEmoji(emoji)}
+                aria-label={`Insert ${emoji}`}
+              >
+                {emoji}
+              </button>
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/components/feed/constants.ts
+++ b/src/components/feed/constants.ts
@@ -5,7 +5,6 @@ import {
   Lightbulb,
   NewspaperIcon,
   Paperclip,
-  PenSquare,
   Rocket,
   Sparkles,
   Video,
@@ -15,10 +14,10 @@ import type { ComposerTab, QuickTag } from "./types";
 
 export const composerTabs: ComposerTab[] = [
   { key: "update", label: "Update", icon: NewspaperIcon },
-  { key: "image", label: "Image", icon: Image, disabled: true },
-  { key: "video", label: "Video", icon: Video, disabled: true },
-  { key: "poll", label: "Poll", icon: BarChart3, disabled: true },
-  { key: "attach", label: "Attach", icon: Paperclip, disabled: true },
+  { key: "image", label: "Image", icon: Image },
+  { key: "video", label: "Video", icon: Video },
+  { key: "poll", label: "Poll", icon: BarChart3 },
+  { key: "attach", label: "Attach", icon: Paperclip },
 ];
 
 export const quickTags: QuickTag[] = [


### PR DESCRIPTION
## Summary
- replace the inline feed composer with a modal-based experience that supports formatting, attachments, and polls
- expose a reusable hook API for creating posts and wire the modal into the feed experience
- refresh feed composer styling to accommodate the launcher card and modal layout

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_690263146ac88325b28a7ce5a7852899